### PR TITLE
[FFM-3838]: Android SDK does not handle target-segment events

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -141,7 +141,7 @@ public class CfClient implements Destroyable {
 
             case EVALUATION_RELOAD:
 
-                CfLog.OUT.v(logTag, "We are about to reload");
+                CfLog.OUT.v(logTag, "Reloading all evaluations");
 
                 this.featureRepository.getAllEvaluations(
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -185,7 +185,13 @@ public class CfClient implements Destroyable {
         });
     }
 
-    private void notifyListeners(Evaluation evaluation) {
+    private void notifyListeners(final Evaluation evaluation) {
+
+        if (evaluation == null) {
+
+            CfLog.OUT.e(logTag, "Evaluation is null");
+            return;
+        }
 
         if (evaluationListenerSet.containsKey(evaluation.getFlag())) {
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -96,10 +96,12 @@ public class CfClient implements Destroyable {
         final String cluster = authInfo.getCluster();
 
         switch (statusEvent.getEventType()) {
+
             case SSE_START:
 
                 evaluationPolling.stop();
                 break;
+
             case SSE_END:
 
                 if (networkInfoProvider.isNetworkAvailable()) {
@@ -129,12 +131,14 @@ public class CfClient implements Destroyable {
                 notifyListeners(e);
 
                 break;
+
             case EVALUATION_REMOVE:
 
                 Evaluation eval = statusEvent.extractPayload();
                 featureRepository.remove(authInfo.getEnvironmentIdentifier(), target.getIdentifier(), eval.getFlag());
                 break;
         }
+
         sendEvent(statusEvent);
     };
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -137,6 +137,13 @@ public class CfClient implements Destroyable {
                 Evaluation eval = statusEvent.extractPayload();
                 featureRepository.remove(authInfo.getEnvironmentIdentifier(), target.getIdentifier(), eval.getFlag());
                 break;
+
+            case EVALUATION_RELOAD:
+
+                CfLog.OUT.v(logTag, "We are about to reload");
+                // TODO
+
+                break;
         }
 
         sendEvent(statusEvent);
@@ -257,14 +264,18 @@ public class CfClient implements Destroyable {
                 if (useStream) {
 
                     startSSE();
+
                 } else {
 
                     evaluationPolling.start(this::reschedule);
                 }
+
             } catch (Exception e) {
 
                 CfLog.OUT.e(logTag, e.getMessage(), e);
+
                 if (networkInfoProvider.isNetworkAvailable()) {
+
                     evaluationPolling.start(this::reschedule);
                 }
             }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -47,7 +47,7 @@ public class SSEListener implements ServerSentEvent.Listener {
             String identifier = jsonObject.getString("identifier");
             String eventType = jsonObject.getString("event");
 
-            Evaluation evaluation = new Evaluation();
+            final Evaluation evaluation = new Evaluation();
             evaluation.flag(identifier);
 
             CfLog.OUT.v(
@@ -58,17 +58,17 @@ public class SSEListener implements ServerSentEvent.Listener {
 
             if ("create".equals(eventType) || "patch".equals(eventType)) {
 
-                eventsListener.onEventReceived(
+                final StatusEvent statusEvent =
+                        new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_CHANGE, evaluation);
 
-                        new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_CHANGE, evaluation)
-                );
+                eventsListener.onEventReceived(statusEvent);
 
             } else if ("delete".equals(eventType)) {
 
-                eventsListener.onEventReceived(
+                final StatusEvent statusEvent =
+                        new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_REMOVE, evaluation);
 
-                        new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_REMOVE, evaluation)
-                );
+                eventsListener.onEventReceived(statusEvent);
             }
 
         } catch (JSONException e) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -44,8 +44,10 @@ public class SSEListener implements ServerSentEvent.Listener {
         try {
 
             jsonObject = new JSONObject(message);
-            String identifier = jsonObject.getString("identifier");
+
+            String domain = jsonObject.getString("domain");
             String eventType = jsonObject.getString("event");
+            String identifier = jsonObject.getString("identifier");
 
             final Evaluation evaluation = new Evaluation();
             evaluation.flag(identifier);
@@ -53,7 +55,11 @@ public class SSEListener implements ServerSentEvent.Listener {
             CfLog.OUT.v(
 
                     logTag,
-                    String.format("onMessage(): eventType=%s, identifier=%s", eventType, identifier)
+                    String.format(
+
+                            "onMessage(): domain=%s, eventType=%s, identifier=%s",
+                            domain, eventType, identifier
+                    )
             );
 
             if ("create".equals(eventType) || "patch".equals(eventType)) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -50,12 +50,19 @@ public class SSEListener implements ServerSentEvent.Listener {
             Evaluation evaluation = new Evaluation();
             evaluation.flag(identifier);
 
+            CfLog.OUT.v(
+
+                    logTag,
+                    String.format("onMessage(): eventType=%s, identifier=%s", eventType, identifier)
+            );
+
             if ("create".equals(eventType) || "patch".equals(eventType)) {
 
                 eventsListener.onEventReceived(
 
                         new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_CHANGE, evaluation)
                 );
+
             } else if ("delete".equals(eventType)) {
 
                 eventsListener.onEventReceived(
@@ -63,6 +70,7 @@ public class SSEListener implements ServerSentEvent.Listener {
                         new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_REMOVE, evaluation)
                 );
             }
+
         } catch (JSONException e) {
 
             CfLog.OUT.e(logTag, e.getMessage(), e);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -62,7 +62,17 @@ public class SSEListener implements ServerSentEvent.Listener {
                     )
             );
 
-            if ("create".equals(eventType) || "patch".equals(eventType)) {
+            if (
+                    ("delete".equals(eventType) || "patch".equals(eventType))  &&
+                            "target-segment".equals(domain)
+            ) {
+
+                final StatusEvent statusEvent =
+                        new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, evaluation);
+
+                eventsListener.onEventReceived(statusEvent);
+
+            } else if ("create".equals(eventType) || "patch".equals(eventType)) {
 
                 final StatusEvent statusEvent =
                         new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_CHANGE, evaluation);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
@@ -68,7 +68,11 @@ public class FeatureRepositoryImpl implements FeatureRepository {
 
         final String envKey = environment + "_" + target;
 
+        CfLog.OUT.v(tag, "getAllEvaluations(): " + envKey);
+
         if (!networkInfoProvider.isNetworkAvailable()) {
+
+            CfLog.OUT.v(tag, "getAllEvaluations(), returning from the cache: " + envKey);
 
             return this.cloudCache.getAllEvaluations(envKey);
         }
@@ -79,7 +83,13 @@ public class FeatureRepositoryImpl implements FeatureRepository {
             final List<Evaluation> evaluationList = apiResponse.body();
             cloudCache.saveAllEvaluations(envKey, evaluationList);
 
-            CfLog.OUT.v(tag, "Got all evaluations: " + evaluationList.size());
+            CfLog.OUT.v(
+
+                    tag,
+                    "getAllEvaluations(), returning from the cloud, size: " +
+                            evaluationList.size()
+            );
+
             return evaluationList;
         }
 

--- a/examples/example/src/main/java/io/harness/cfsdk/example/MainActivity.kt
+++ b/examples/example/src/main/java/io/harness/cfsdk/example/MainActivity.kt
@@ -67,7 +67,7 @@ class MainActivity : AppCompatActivity() {
                 val logPrefix = keyName + " :: " + client.hashCode()
 
                 val config = CfConfiguration.builder()
-                    .enableAnalytics(false)
+                    .enableAnalytics(true)
                     .enableStream(true)
                     .build()
 
@@ -103,18 +103,18 @@ class MainActivity : AppCompatActivity() {
                             val timer = Timer()
                             timers[keyName] = timer
 
-//                            timer.schedule(
-//
-//                                object : TimerTask() {
-//
-//                                    override fun run() {
-//
-//                                        readEvaluations(client, logPrefix)
-//                                    }
-//                                },
-//                                0,
-//                                30000
-//                            )
+                            timer.schedule(
+
+                                object : TimerTask() {
+
+                                    override fun run() {
+
+                                        readEvaluations(client, logPrefix)
+                                    }
+                                },
+                                0,
+                                10000
+                            )
 
                         } catch (e: IllegalStateException) {
 

--- a/examples/example/src/main/java/io/harness/cfsdk/example/MainActivity.kt
+++ b/examples/example/src/main/java/io/harness/cfsdk/example/MainActivity.kt
@@ -24,11 +24,13 @@ class MainActivity : AppCompatActivity() {
         private val keys = mutableMapOf<String, String>()
         private val executor = Executors.newSingleThreadExecutor()
 
-        private const val KEY_UAT = "UAT"
+        private const val KEY_ISSUE = "ISSUE"
+        private const val ISSUE_KEY = "9dcd36d5-fdae-4b01-ab32-a7ad2ffd7ee8"
+//        private const val KEY_UAT = "UAT"
 
-        private const val UAT_KEY = "960a7bda-c1c6-4593-b174-e4a3b7f4ce76"
-        private const val FREEMIUM_API_KEY = "a6efdb72-4c01-45e0-8285-1dcbd63f72e7"
-        private const val NON_FREEMIUM_API_KEY = "d122149a-fadd-471d-ab31-7938a2b90ba2"
+//        private const val UAT_KEY = "960a7bda-c1c6-4593-b174-e4a3b7f4ce76"
+//        private const val FREEMIUM_API_KEY = "a6efdb72-4c01-45e0-8285-1dcbd63f72e7"
+//        private const val NON_FREEMIUM_API_KEY = "d122149a-fadd-471d-ab31-7938a2b90ba2"
     }
 
     private var eventsListener = EventsListener { event ->
@@ -40,44 +42,8 @@ class MainActivity : AppCompatActivity() {
 
         clients.forEach { client ->
 
-            val eval = client.boolVariation("flag1", false)
-            CfLog.OUT.v(logTag, "flag1 value: $eval")
-        }
-    }
-
-    private val otherFlagListener: EvaluationListener = EvaluationListener {
-
-        clients.forEach { client ->
-
-            val eval = client.boolVariation("harnessappdemoenablecimodule", false)
-            CfLog.OUT.v(logTag, "harnessappdemoenablecimodule value: $eval")
-        }
-    }
-
-    private val flag2Listener: EvaluationListener = EvaluationListener {
-
-        clients.forEach { client ->
-
-            val eval = client.numberVariation("flag2", -1.0)
-            CfLog.OUT.v(logTag, "flag2 value: $eval")
-        }
-    }
-
-    private val flag3Listener: EvaluationListener = EvaluationListener {
-
-        clients.forEach { client ->
-
-            val eval = client.stringVariation("flag3", "NO_VALUE!!!")
-            CfLog.OUT.v(logTag, "flag3 value: $eval")
-        }
-    }
-
-    private val flag4Listener: EvaluationListener = EvaluationListener {
-
-        clients.forEach { client ->
-
-            val eval = client.jsonVariation("flag4", JSONObject())
-            CfLog.OUT.v(logTag, "flag4 value: $eval")
+            val eval = client.boolVariation("harnessappdemodarkmode", false)
+            CfLog.OUT.v(logTag, "harnessappdemodarkmode value: $eval")
         }
     }
 
@@ -86,12 +52,10 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        keys[KEY_UAT] = UAT_KEY
-//        keys["Freemium"] = FREEMIUM_API_KEY
-//        keys["Non-Freemium"] = NON_FREEMIUM_API_KEY
+        keys[KEY_ISSUE] = ISSUE_KEY
 
-        val uuid = UUID.randomUUID().toString()
-        val target = Target().identifier(uuid).name(uuid)
+        val targetName = "android1"
+        val target = Target().identifier(targetName).name(targetName)
 
         keys.forEach { (keyName, apiKey) ->
 
@@ -102,20 +66,8 @@ class MainActivity : AppCompatActivity() {
 
                 val logPrefix = keyName + " :: " + client.hashCode()
 
-                val builder = CfConfiguration.builder()
-                    .enableAnalytics(true)
-
-                if (keyName == KEY_UAT) {
-
-                    CfLog.OUT.v(logTag, "Setting up the UAT url(s)")
-
-                    builder
-                        .baseUrl("https://config.feature-flags.uat.harness.io/api/1.0")
-                        .eventUrl("https://event.feature-flags.uat.harness.io/api/1.0")
-                        .streamUrl("https://config.feature-flags.uat.harness.io/api/1.0/stream")
-                }
-
-                val config = builder
+                val config = CfConfiguration.builder()
+                    .enableAnalytics(false)
                     .enableStream(true)
                     .build()
 
@@ -141,33 +93,7 @@ class MainActivity : AppCompatActivity() {
                             registerEvaluationsOk++
                         }
 
-                        if (
-                            client.registerEvaluationListener(
-
-                                "harnessappdemoenablecimodule",
-                                otherFlagListener
-                            )
-                        ) {
-
-                            registerEvaluationsOk++
-                        }
-
-                        if (client.registerEvaluationListener("flag2", flag2Listener)) {
-
-                            registerEvaluationsOk++
-                        }
-
-                        if (client.registerEvaluationListener("flag3", flag3Listener)) {
-
-                            registerEvaluationsOk++
-                        }
-
-                        if (client.registerEvaluationListener("flag4", flag4Listener)) {
-
-                            registerEvaluationsOk++
-                        }
-
-                        if (registerEventsOk && registerEvaluationsOk == 4) {
+                        if (registerEventsOk && registerEvaluationsOk > 0) {
 
                             CfLog.OUT.i(logTag, "$logPrefix Registrations OK")
                         }
@@ -177,18 +103,18 @@ class MainActivity : AppCompatActivity() {
                             val timer = Timer()
                             timers[keyName] = timer
 
-                            timer.schedule(
-
-                                object : TimerTask() {
-
-                                    override fun run() {
-
-                                        readEvaluations(client, logPrefix)
-                                    }
-                                },
-                                0,
-                                10000
-                            )
+//                            timer.schedule(
+//
+//                                object : TimerTask() {
+//
+//                                    override fun run() {
+//
+//                                        readEvaluations(client, logPrefix)
+//                                    }
+//                                },
+//                                0,
+//                                30000
+//                            )
 
                         } catch (e: IllegalStateException) {
 
@@ -227,20 +153,8 @@ class MainActivity : AppCompatActivity() {
 
     private fun readEvaluations(client: CfClient, logPrefix: String) {
 
-        var bVal = client.boolVariation("flag1", false)
-        CfLog.OUT.v(logTag, "$logPrefix flag1: $bVal")
-
-        val nVal = client.numberVariation("flag2", -1.0)
-        CfLog.OUT.v(logTag, "$logPrefix flag2: $nVal")
-
-        val sVal = client.stringVariation("flag3", "NO_VALUE!!!")
-        CfLog.OUT.v(logTag, "$logPrefix flag3: $sVal")
-
-        val jVal = client.jsonVariation("flag4", JSONObject())
-        CfLog.OUT.v(logTag, "$logPrefix flag4: $jVal")
-
-        bVal = client.boolVariation("harnessappdemoenablecimodule", false)
-        CfLog.OUT.v(logTag, "$logPrefix harnessappdemoenablecimodule: $bVal")
+        val bVal = client.boolVariation("harnessappdemodarkmode", false)
+        CfLog.OUT.v(logTag, "$logPrefix harnessappdemodarkmode: $bVal")
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
## What
Add support to handle target segment events.  When an event is received we make a call to get all evaluations.

## Why
When a group rule is changed on the FF server, the SDK receives an event.  The SDK needs to fetch all flag evaluations again as the change to the group could impact what variations a target is served for any given flag.

