### PR TITLE
FFM-4605 - Fix issue where double escaped response was causing exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ buildscript {
 
 In app module's [build.gradle](https://github.com/harness/ff-android-client-sdk/blob/main/examples/GettingStarted/app/build.gradle#L41) file add dependency for Harness's SDK
 
-`implementation 'io.harness:ff-android-client-sdk:1.0.10'`
+`implementation 'io.harness:ff-android-client-sdk:1.0.11'`
 
 
 ### Code Sample

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -11,6 +11,8 @@ android {
 
         minSdkVersion 19
         targetSdkVersion 31
+        versionCode 12
+        versionName "1.0.11"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -11,8 +11,6 @@ android {
 
         minSdkVersion 19
         targetSdkVersion 31
-        versionCode 11
-        versionName "1.0.10"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -45,6 +43,7 @@ apply from: "${rootProject.projectDir}/cfsdk/publish-mavencentral.gradle"
 dependencies {
 
     implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'org.apache.commons:commons-lang3:3.11'
 
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.10"
+    PUBLISH_VERSION = "1.0.11"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import androidx.annotation.Nullable;
 
+import org.apache.commons.lang3.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -764,8 +765,9 @@ public class CfClient implements Destroyable {
 
                     return e.getValue();
                 }
-
-                return new JSONObject((String) e.getValue());
+                String eval = StringEscapeUtils.unescapeJava(e.getValue().toString());
+                eval = eval.substring(1, eval.length() - 1);
+                return new JSONObject(eval);
             }
         } catch (JSONException e) {
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -257,7 +257,7 @@ public class AnalyticsPublisherService {
             setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, GLOBAL_TARGET);
             setMetricsAttributes(metricsData, SDK_TYPE, CLIENT);
             setMetricsAttributes(metricsData, SDK_LANGUAGE, "android");
-            setMetricsAttributes(metricsData, SDK_VERSION, "1.0.10");
+            setMetricsAttributes(metricsData, SDK_VERSION, "1.0.11");
 
             metrics.addMetricsDataItem(metricsData);
         }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -29,7 +29,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
             ApiClient apiClient = metricsAPI.getApiClient();
             apiClient.setBasePath(config.getEventURL());
             apiClient.addDefaultHeader("Authorization", "Bearer " + authToken);
-            apiClient.setUserAgent("android 1.0.10");
+            apiClient.setUserAgent("android 1.0.11");
             String hostname = "UnknownHost";
 
             try {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
@@ -92,7 +92,7 @@ public class CloudFactory implements ICloudFactory {
     public ApiClient apiClient() {
 
         final ApiClient apiClient = new ApiClient();
-        apiClient.setUserAgent("android 1.0.10");
+        apiClient.setUserAgent("android 1.0.11");
         String hostname = "UnknownHost";
         try {
 

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.10'
+    implementation 'io.harness:ff-android-client-sdk:1.0.11'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
**What** 
Adds fix for jsonVariation function which was not returning a JSON object response because it was throwing an exception

**Why**
As per [FFM-4605](https://harness.atlassian.net/browse/FFM-4605) we found the response was double escaped, so we couldn't cast it to a JSON object

Screen showing successful logging of the object, which previously would have just been 'null'
<img width="547" alt="Screenshot 2022-10-12 at 09 46 06" src="https://user-images.githubusercontent.com/62011008/195301279-aebab4f5-755e-4424-953d-e13ed143b5f3.png">
