### PR TITLE
[FFM-4836]: Mitigate potential race condition during the Android SDK intitialization

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -43,6 +43,7 @@ import io.harness.cfsdk.cloud.repository.FeatureRepository;
 import io.harness.cfsdk.cloud.sse.SSEControlling;
 import io.harness.cfsdk.common.Destroyable;
 import io.harness.cfsdk.logging.CfLog;
+import io.harness.cfsdk.utils.GuardObjectWrapper;
 
 /**
  * Main class used for any operation on SDK. Operations include, but not limited to, reading evaluations and
@@ -71,7 +72,8 @@ public class CfClient implements Destroyable {
     private final Executor listenerUpdateExecutor;
     private final Set<EventsListener> eventsListenerSet;
     private final ConcurrentHashMap<String, Set<EvaluationListener>> evaluationListenerSet;
-
+    private GuardObjectWrapper evaluationPollingLock;
+    
     {
 
         ready = new AtomicBoolean();
@@ -80,6 +82,8 @@ public class CfClient implements Destroyable {
         evaluationListenerSet = new ConcurrentHashMap<>();
         listenerUpdateExecutor = Executors.newSingleThreadExecutor();
         eventsListenerSet = Collections.synchronizedSet(new LinkedHashSet<>());
+        evaluationPollingLock = new GuardObjectWrapper();
+
     }
 
     private final EventsListener eventsListener = statusEvent -> {
@@ -311,7 +315,8 @@ public class CfClient implements Destroyable {
 
                 reschedule();
             } else {
-
+                // waiting for the lock to be release.
+                evaluationPollingLock.get();
                 evaluationPolling.stop();
             }
         });
@@ -369,8 +374,9 @@ public class CfClient implements Destroyable {
             throw new IllegalStateException("Already initialized");
         }
 
-        setupNetworkInfo(context);
-        doInitialize(
+        setupNetworkInfo(context);  // evaluationPoll.stop()
+
+        doInitialize(       // evaluationPoll - defined.
 
                 apiKey,
                 configuration,
@@ -378,6 +384,8 @@ public class CfClient implements Destroyable {
                 cloudCache,
                 authCallback
         );
+
+
     }
 
     /**
@@ -511,6 +519,8 @@ public class CfClient implements Destroyable {
 
                 featureRepository = cloudFactory.getFeatureRepository(cloud, cloudCache, networkInfoProvider);
                 evaluationPolling = cloudFactory.evaluationPolling(configuration.getPollingInterval(), TimeUnit.SECONDS);
+                // release the lock.
+                evaluationPollingLock.set(evaluationPolling);
 
                 this.useStream = configuration.getStreamEnabled();
                 this.analyticsEnabled = configuration.isAnalyticsEnabled();

--- a/cfsdk/src/main/java/io/harness/cfsdk/utils/GuardObjectWrapper.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/utils/GuardObjectWrapper.java
@@ -1,0 +1,27 @@
+package io.harness.cfsdk.utils;
+
+import java.util.concurrent.CountDownLatch;
+
+/* Can be used to ensure method cannot be called on uninitialized object.*/
+public class GuardObjectWrapper {
+
+    private Object object;
+
+
+    private final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+    public Object get(){
+        try {
+            countDownLatch.await(); // wait for 0
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        return object;
+    }
+
+    public void set(Object newObject){
+        // this will release other thread when 0
+        this.object = newObject;
+        countDownLatch.countDown();
+    }
+}

--- a/cfsdk/src/main/java/io/harness/cfsdk/utils/GuardObjectWrapper.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/utils/GuardObjectWrapper.java
@@ -2,16 +2,20 @@ package io.harness.cfsdk.utils;
 
 import java.util.concurrent.CountDownLatch;
 
+import io.harness.cfsdk.CfClient;
+import io.harness.cfsdk.logging.CfLog;
+
 /* Can be used to ensure method cannot be called on uninitialized object.*/
 public class GuardObjectWrapper {
 
     private Object object;
-
+    private String tag = GuardObjectWrapper.class.getSimpleName();
 
     private final CountDownLatch countDownLatch = new CountDownLatch(1);
 
     public Object get(){
         try {
+            CfLog.OUT.v(tag, "Awaiting for lock release");
             countDownLatch.await(); // wait for 0
         } catch (InterruptedException e) {
             throw new RuntimeException(e);
@@ -20,7 +24,9 @@ public class GuardObjectWrapper {
     }
 
     public void set(Object newObject){
+
         // this will release other thread when 0
+        CfLog.OUT.v(tag, "Releasing lock "+ newObject.getClass().getSimpleName());
         this.object = newObject;
         countDownLatch.countDown();
     }


### PR DESCRIPTION
[FFM-4836]: Mitigate potential race condition during the Android SDK intitialization

 #What: 
Added GuardObjectWrapper to ensure evaluationPolling.stop() is not called on uninitialized object.
 #Why:
To fix potential race condition.
 #Testing:
Tested locally by initializing sdk on the emulator.







[FFM-4836]: https://harness.atlassian.net/browse/FFM-4836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ