### PR TITLE
[FFM-5484] Reset cache on init if exception is thrown

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
@@ -27,7 +27,18 @@ public class DefaultCache implements CloudCache {
 
         key_all = "all_evaluations";
         executor = Executors.newSingleThreadExecutor();
-        evaluations = new ConcurrentHashMap<>(Hawk.get(key_all, new ConcurrentHashMap<>()));
+
+        ConcurrentHashMap<String, ConcurrentHashMap<String, Evaluation>> evaluationsTemp;
+
+        try {
+            evaluationsTemp = new ConcurrentHashMap<>(Hawk.get(key_all, new ConcurrentHashMap<>()));
+        } catch (Exception ex) {
+            // Possible cache corruption, reset the cache on disk and let it rebuild
+            Hawk.deleteAll();
+            evaluationsTemp = new ConcurrentHashMap<>(Hawk.get(key_all, new ConcurrentHashMap<>()));
+        }
+
+        evaluations = evaluationsTemp;
     }
 
     @Override


### PR DESCRIPTION
[FFM-5484] Reset cache on init if exception is thrown

What
If we get an exception while loading the initial list of evaluations from the cache then assume cache has gotten corrupt on disk and reset it.

Why
We're seeing type exceptions on the initialize() method on startup which looks to be caused by a corrupt cache on disk. This will remove any bad entries.

Testing
Manual - changed the underlying xml to get it to throw and exception

[FFM-5484]: https://harness.atlassian.net/browse/FFM-5484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ