### PR TITLE
FFM-6156 Sent actual target in metrics

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -689,7 +689,7 @@ public class CfClient implements Destroyable {
 
             final Variation variation = new Variation();
             variation.setName(evaluationId);
-            variation.setValue(String.valueOf(result));
+            variation.setValue(String.valueOf(result.value));
             variation.setIdentifier(result.getIdentifier());
 
             if (!analyticsManager.pushToQueue(this.target, evaluationId, variation)) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -31,6 +31,7 @@ public class AnalyticsPublisherService {
     private static final String FEATURE_IDENTIFIER_ATTRIBUTE;
     private static final String FEATURE_NAME_ATTRIBUTE;
     private static final String VARIATION_IDENTIFIER_ATTRIBUTE;
+    private static final String VARIATION_VALUE_ATTRIBUTE;
 
     static {
 
@@ -43,6 +44,7 @@ public class AnalyticsPublisherService {
         FEATURE_IDENTIFIER_ATTRIBUTE = "featureIdentifier";
         FEATURE_NAME_ATTRIBUTE = "featureName";
         VARIATION_IDENTIFIER_ATTRIBUTE = "variationIdentifier";
+        VARIATION_VALUE_ATTRIBUTE = "variationValue";
     }
 
     private final String logTag;

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -259,7 +259,8 @@ public class AnalyticsPublisherService {
             setMetricsAttributes(metricsData, FEATURE_IDENTIFIER_ATTRIBUTE, entry.getKey().getFeatureName());
             setMetricsAttributes(metricsData, FEATURE_NAME_ATTRIBUTE, entry.getKey().getFeatureName());
             setMetricsAttributes(metricsData, VARIATION_IDENTIFIER_ATTRIBUTE, entry.getKey().getVariationIdentifier());
-            setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, GLOBAL_TARGET);
+            setMetricsAttributes(metricsData, VARIATION_VALUE_ATTRIBUTE, entry.getKey().getVariationValue());
+            setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, entry.getKey().getTarget());
             setMetricsAttributes(metricsData, SDK_TYPE, CLIENT);
             setMetricsAttributes(metricsData, SDK_LANGUAGE, "android");
             setMetricsAttributes(metricsData, SDK_VERSION, "1.0.14");
@@ -287,7 +288,8 @@ public class AnalyticsPublisherService {
 
                 key.getVariation().getName(),
                 key.getVariation().getValue(),
-                key.getVariation().getIdentifier()
+                key.getVariation().getIdentifier(),
+                key.getTarget().getIdentifier()
         );
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/SummaryMetrics.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/SummaryMetrics.java
@@ -5,12 +5,14 @@ public class SummaryMetrics {
     private String featureName;
     private String variationValue;
     private String variationIdentifier;
+    private String target;
 
-    public SummaryMetrics(String featureName, String variationValue, String variationIdentifier) {
+    public SummaryMetrics(String featureName, String variationValue, String variationIdentifier, String target) {
 
         this.featureName = featureName;
         this.variationValue = variationValue;
         this.variationIdentifier = variationIdentifier;
+        this.target = target;
     }
 
     public String getFeatureName() {
@@ -41,6 +43,14 @@ public class SummaryMetrics {
     public void setVariationValue(String variationValue) {
 
         this.variationValue = variationValue;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
     }
 
     @Override


### PR DESCRIPTION
# What
- In `metricsData` the global target was being used instead of the actual target. This changes the `target` attribute to use the actual target.
- `variationValue` attribute wasn't being sent in `metricsData` - while this didn't have a problem with metrics appearing posting and appearing in the UI, the metrics service asks for this data. This adds the variationValue to the `metricsData` payload.

# Why
- Client SDKs should send the actual target
- To honour the metrics API

# Testing
- Metrics continue to post and appear in the UI.
- Debugged the application and saw that the actual target was in the metrics payload

