### PR TITLE
FFM-6144 - Android SDK Type casting

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ buildscript {
 
 In app module's [build.gradle](https://github.com/harness/ff-android-client-sdk/blob/main/examples/GettingStarted/app/build.gradle#L41) file add dependency for Harness's SDK
 
-`implementation 'io.harness:ff-android-client-sdk:1.0.15'`
+`implementation 'io.harness:ff-android-client-sdk:1.0.16'`
 
 
 ### Code Sample

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.0.15"
+        versionName "1.0.16"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -57,8 +57,7 @@ dependencies {
     implementation 'com.orhanobut:hawk:2.0.1'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.1.0'
-
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    testImplementation 'org.mockito:mockito-core:4.10.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    testImplementation 'org.json:json:20180813'
 }

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.15"
+    PUBLISH_VERSION = "1.0.16"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -263,7 +263,7 @@ public class AnalyticsPublisherService {
             setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, entry.getKey().getTarget());
             setMetricsAttributes(metricsData, SDK_TYPE, CLIENT);
             setMetricsAttributes(metricsData, SDK_LANGUAGE, "android");
-            setMetricsAttributes(metricsData, SDK_VERSION, "1.0.15");
+            setMetricsAttributes(metricsData, SDK_VERSION, "1.0.16");
 
             metrics.addMetricsDataItem(metricsData);
         }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -29,7 +29,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
             ApiClient apiClient = metricsAPI.getApiClient();
             apiClient.setBasePath(config.getEventURL());
             apiClient.addDefaultHeader("Authorization", "Bearer " + authToken);
-            apiClient.setUserAgent("android 1.0.15");
+            apiClient.setUserAgent("android 1.0.16");
             String hostname = "UnknownHost";
 
             try {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
@@ -92,7 +92,7 @@ public class CloudFactory implements ICloudFactory {
     public ApiClient apiClient() {
 
         final ApiClient apiClient = new ApiClient();
-        apiClient.setUserAgent("android 1.0.15");
+        apiClient.setUserAgent("android 1.0.16");
         String hostname = "UnknownHost";
         try {
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/logging/CfLogStrategyDefault.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/logging/CfLogStrategyDefault.java
@@ -40,27 +40,27 @@ public class CfLogStrategyDefault implements CfLogging {
 
     @Override
     public void v(String tag, String message, Throwable throwable) {
-
+        Log.v(tag, message, throwable);
     }
 
     @Override
     public void d(String tag, String message, Throwable throwable) {
-
+        Log.d(tag, message, throwable);
     }
 
     @Override
     public void i(String tag, String message, Throwable throwable) {
-
+        Log.i(tag, message, throwable);
     }
 
     @Override
     public void w(String tag, String message, Throwable throwable) {
-
+        Log.w(tag, message, throwable);
     }
 
     @Override
     public void e(String tag, String message, Throwable throwable) {
-
+        Log.e(tag, message, throwable);
         Log.e(tag, message, throwable);
     }
 

--- a/cfsdk/src/test/java/android/util/Base64.java
+++ b/cfsdk/src/test/java/android/util/Base64.java
@@ -1,0 +1,12 @@
+package android.util;
+
+/**
+ * Mock implementation for Android native classes
+ */
+public class Base64 {
+
+    public static byte[] decode(String str, int flags) {
+        return java.util.Base64.getDecoder().decode(str);
+    }
+
+}

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -1,0 +1,141 @@
+package io.harness.cfsdk;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static io.harness.cfsdk.TestUtils.makeAuthResponse;
+import static io.harness.cfsdk.TestUtils.makeBasicEvaluationsListJson;
+import static io.harness.cfsdk.TestUtils.makeFlagCreateEvent;
+import static io.harness.cfsdk.TestUtils.makeFlagDeleteEvent;
+import static io.harness.cfsdk.TestUtils.makeMockJsonResponse;
+import static io.harness.cfsdk.TestUtils.makeMockStreamResponse;
+import static io.harness.cfsdk.TestUtils.makeServerUrl;
+import static io.harness.cfsdk.TestUtils.makeSingleEvaluationJson;
+import static io.harness.cfsdk.TestUtils.makeTargetSegmentCreateEvent;
+import static io.harness.cfsdk.TestUtils.makeTargetSegmentPatchEvent;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATION_CHANGE;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATION_RELOAD;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATION_REMOVE;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.SSE_END;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.SSE_START;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+import io.harness.cfsdk.cloud.model.Target;
+import io.harness.cfsdk.cloud.oksse.model.StatusEvent;
+import io.harness.cfsdk.logging.CfLog;
+import io.harness.cfsdk.mock.MockedCache;
+import io.harness.cfsdk.mock.MockedNetworkInfoProvider;
+import io.harness.cfsdk.utils.EventsListenerCounter;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+
+/**
+ * Runs CfClient with a mocked ff-server
+ */
+public class CfClientTest {
+
+    private static final String logTag = CfClientTest.class.getSimpleName();
+
+    static class MockWebServerDispatcher extends Dispatcher {
+        private final AtomicInteger version = new AtomicInteger(2);
+        @NonNull
+        @Override
+        public MockResponse dispatch(RecordedRequest request) {
+
+            System.out.println("MOCK WEB SERVER GOT ------> " + request.getPath());
+
+            switch (Objects.requireNonNull(request.getPath())) {
+                case "/api/1.0/client/auth":
+                    return makeAuthResponse();
+                case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations?cluster=1":
+                    return makeMockJsonResponse(200, makeBasicEvaluationsListJson());
+                case "/api/1.0?cluster=1":
+                    return makeMockStreamResponse(200,
+                            makeTargetSegmentCreateEvent("anyone@anywhere.com", version.getAndIncrement()),
+                            makeTargetSegmentPatchEvent("anyone@anywhere.com", version.getAndIncrement()),
+                            makeFlagCreateEvent("anyone@anywhere.com", version.getAndIncrement()),
+                            makeFlagDeleteEvent("anyone@anywhere.com", version.getAndIncrement())
+                    );
+                case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations/anyone%40anywhere.com?cluster=1":
+                    return  makeMockJsonResponse(200, makeSingleEvaluationJson());
+
+            }
+
+            throw new UnsupportedOperationException("ERROR: url not mapped " + request.getPath());
+        }
+    }
+
+    @Test
+    public void testRegisterEventsListener() throws Exception {
+
+        CfLog.testModeOn();
+
+        try (MockWebServer mockSvr = new MockWebServer()) {
+            mockSvr.setDispatcher(new MockWebServerDispatcher());
+            mockSvr.start();
+
+            final EventsListenerCounter eventCounter = new EventsListenerCounter(7); // Make sure this number matches assertions total below
+            final CfClient client = new CfClient();
+            client.setNetworkInfoProvider(new MockedNetworkInfoProvider());
+            client.registerEventsListener(eventCounter);
+
+            final CfConfiguration config = CfConfiguration.builder()
+                    .baseUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                    .streamUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                    .eventUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                    .enableAnalytics(false)
+                    .enableStream(true)
+                    .build();
+
+            final Target target = new Target().identifier("anyone@anywhere.com").name("unit-test");
+            final Context mockContext = mock(Context.class);
+
+            client.initialize(
+                    mockContext,
+                    "dummykey",
+                    config,
+                    target,
+                    new MockedCache()
+            );
+
+            eventCounter.waitForAllEventsOrTimeout(30);
+
+            assertEquals((Long) 1L, (Long) eventCounter.getCountFor(SSE_START));
+            assertEquals((Long) 3L, (Long) eventCounter.getCountFor(EVALUATION_RELOAD));
+            assertEquals((Long) 1L, (Long) eventCounter.getCountFor(EVALUATION_CHANGE));
+            assertEquals((Long) 1L, (Long) eventCounter.getCountFor(EVALUATION_REMOVE));
+            assertEquals((Long) 1L, (Long) eventCounter.getCountFor(SSE_END));
+            assertEquals((Long) 0L, (Long) eventCounter.getCountForUnknown());
+
+        }
+    }
+
+    @Test
+    public void evaluationReloadEventShouldSendCorrectPayload() throws InterruptedException {
+
+        CfLog.testModeOn();
+
+        final EventsListenerCounter eventCounter = new EventsListenerCounter(1);
+        final CfClient client = new CfClient();
+        client.registerEventsListener(eventCounter);
+
+        client.sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, new Evaluation())); // invalid, will be filtered out
+        client.sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, Collections.singletonList(new Evaluation()))); // valid
+        eventCounter.waitForAllEventsOrTimeout(30);
+
+        assertEquals((Long) 1L, (Long) eventCounter.getCountFor(EVALUATION_RELOAD));
+    }
+
+
+}

--- a/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
@@ -1,0 +1,108 @@
+package io.harness.cfsdk;
+
+import com.google.gson.Gson;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+import okhttp3.mockwebserver.MockResponse;
+
+public class TestUtils {
+
+    static class Event {
+        public Event(String event, String domain, String identifier, int version) {
+            this.event = event;
+            this.domain = domain;
+            this.identifier = identifier;
+            this.version = version;
+        }
+
+        final String event, domain, identifier;
+        final int version;
+    }
+
+    static MockResponse makeMockJsonResponse(int httpCode, String body) {
+        return new MockResponse()
+                .setResponseCode(httpCode)
+                .setBody(body)
+                .addHeader("Content-Type", "application/json; charset=UTF-8");
+    }
+
+    static String makeBasicEvaluationsListJson() {
+        final List<Evaluation> list = new ArrayList<>();
+        list.add(new Evaluation().flag("testFlag").kind("fixme").value("on").identifier("anyone@anywhere.com"));
+
+        return new Gson().toJson(list);
+    }
+
+    static String makeSingleEvaluationJson() {
+        final Evaluation eval = new Evaluation().flag("testFlag").kind("fixme").value("on").identifier("anyone@anywhere.com");
+        return new Gson().toJson(eval);
+    }
+
+    static MockResponse makeAuthResponse() {
+        return makeMockJsonResponse(200, "{\"authToken\": \"" + makeDummyJwtToken() + "\"}");
+    }
+
+    static Event makeTargetSegmentPatchEvent(String identifier, int version) {
+        return makeEvent("patch", "target-segment", identifier, version);
+    }
+
+    static Event makeTargetSegmentCreateEvent(String identifier, int version) {
+        return makeEvent("create", "target-segment", identifier, version);
+    }
+
+    static Event makeFlagCreateEvent(String identifier, int version) {
+        return makeEvent("create", "flag", identifier, version);
+    }
+
+    static Event makeFlagDeleteEvent(String identifier, int version) {
+        return makeEvent("delete", "flag", identifier, version);
+    }
+
+    static Event makeEvent(String event, String domain, String identifier, int version) {
+        return new Event(event, domain, identifier, version);
+    }
+
+    static MockResponse makeMockStreamResponse(int httpCode, Event... events) {
+
+        final StringBuilder builder = new StringBuilder();
+        Arrays.stream(events)
+                .forEach(
+                        e -> builder.append("event: *\ndata: ").append(new Gson().toJson(e)).append("\n\n"));
+
+        return new MockResponse()
+                .setResponseCode(httpCode)
+                .setBody(builder.toString())
+                .addHeader("Content-Type", "text/event-stream; charset=UTF-8")
+                .addHeader("Accept-Encoding", "identity");
+    }
+
+    static String makeServerUrl(String host, int port) {
+        return  String.format("http://%s:%s/api/1.0", host, port);
+    }
+
+    static String makeDummyJwtToken() {
+        final String header = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}";
+        final String payload =
+                "{\"environment\":\"00000000-0000-0000-0000-000000000000\","
+                        + "\"environmentIdentifier\":\"Production\","
+                        + "\"project\":\"00000000-0000-0000-0000-000000000000\","
+                        + "\"projectIdentifier\":\"dev\","
+                        + "\"accountID\":\"aaaaa_BBBBB-cccccccccc\","
+                        + "\"organization\":\"00000000-0000-0000-0000-000000000000\","
+                        + "\"organizationIdentifier\":\"default\","
+                        + "\"clusterIdentifier\":\"1\","
+                        + "\"key_type\":\"Server\"}";
+        final byte[] hmac256 = new byte[32];
+        return Base64.getEncoder().encodeToString(header.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getEncoder().encodeToString(payload.getBytes(StandardCharsets.UTF_8))
+                + "."
+                + Base64.getEncoder().encodeToString(hmac256);
+    }
+}

--- a/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedCache.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedCache.java
@@ -1,0 +1,110 @@
+package io.harness.cfsdk.mock;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import io.harness.cfsdk.cloud.cache.CloudCache;
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+
+public class MockedCache implements CloudCache {
+
+    private final Executor executor;
+    private final ConcurrentHashMap<String, ConcurrentHashMap<String, Evaluation>> evaluations;
+
+    public MockedCache() {
+
+        executor = Executors.newSingleThreadExecutor();
+
+        ConcurrentHashMap<String, ConcurrentHashMap<String, Evaluation>> evaluationsTemp;
+
+        evaluations =  new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Evaluation getEvaluation(final String env, final String key) {
+
+        final ConcurrentHashMap<String, Evaluation> items = evaluations.get(env);
+        if (items != null) {
+
+            return items.get(key);
+        }
+        return null;
+    }
+
+    @Override
+    public void saveEvaluation(final String env, final String key, final Evaluation evaluation) {
+
+        final Runnable action = () -> {
+
+            ConcurrentHashMap<String, Evaluation> items = evaluations.get(env);
+            if (items == null) {
+
+                items = new ConcurrentHashMap<>();
+                evaluations.put(env, items);
+            }
+            items.put(key, evaluation);
+
+        };
+
+        executor.execute(action);
+    }
+
+    @Override
+    public List<Evaluation> getAllEvaluations(final String env) {
+
+        final ConcurrentHashMap<String, Evaluation> items = evaluations.get(env);
+        if (items != null) {
+
+            return new LinkedList<>(items.values());
+        }
+        return new LinkedList<>();
+    }
+
+    @Override
+    public void saveAllEvaluations(final String env, final List<Evaluation> newEvaluations) {
+
+        final Runnable action = () -> {
+
+            final ConcurrentHashMap<String, Evaluation> items = new ConcurrentHashMap<>();
+            for (final Evaluation item : newEvaluations) {
+
+                items.put(item.getIdentifier(), item);
+            }
+
+            evaluations.put(env, items);
+        };
+
+        executor.execute(action);
+    }
+
+    @Override
+    public void removeEvaluation(final String env, final String key) {
+
+        final Runnable action = () -> {
+
+            final ConcurrentHashMap<String, Evaluation> items = evaluations.get(env);
+            if (items != null) {
+
+                items.remove(key);
+            }
+
+        };
+
+        executor.execute(action);
+    }
+
+    @Override
+    public void clear() {
+
+        final Runnable action = () -> {
+
+            evaluations.clear();
+
+        };
+
+        executor.execute(action);
+    }
+}

--- a/cfsdk/src/test/java/io/harness/cfsdk/utils/EventsListenerCounter.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/utils/EventsListenerCounter.java
@@ -1,0 +1,79 @@
+package io.harness.cfsdk.utils;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.harness.cfsdk.CfClientTest;
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+import io.harness.cfsdk.cloud.oksse.EventsListener;
+import io.harness.cfsdk.cloud.oksse.model.StatusEvent;
+import io.harness.cfsdk.logging.CfLog;
+
+public class EventsListenerCounter implements EventsListener {
+    private static final String logTag = CfClientTest.class.getSimpleName().toUpperCase();
+    private final CountDownLatch latch;
+    private final int numOfValidEventsToWaitFor;
+    private final Map<String, Long> map = new ConcurrentHashMap<>();
+
+    public EventsListenerCounter(int numOfValidEventsToWaitFor) {
+        latch = new CountDownLatch(numOfValidEventsToWaitFor);
+        this.numOfValidEventsToWaitFor = numOfValidEventsToWaitFor;
+        Arrays.stream(StatusEvent.EVENT_TYPE.values()).forEach(e -> map.put(e.name(), 0L));
+        map.put("UNKNOWN", 0L);
+    }
+
+    public void waitForAllEventsOrTimeout(int timeoutInSeconds) throws InterruptedException {
+        if (!latch.await(timeoutInSeconds, TimeUnit.SECONDS)) {
+            fail(String.format("Expected %d events but only got %d", numOfValidEventsToWaitFor, latch.getCount()));
+        }
+    }
+
+    @Override
+    public void onEventReceived(StatusEvent statusEvent) {
+        final String name = statusEvent.getEventType().name();
+        final String payloadInfo = (statusEvent.extractPayload() == null) ? "NULL" : statusEvent.extractPayload().getClass().getSimpleName();
+        CfLog.OUT.i(logTag, String.format("onEventReceived  ----------> type=%s payload=%s", name, payloadInfo));
+
+        switch (statusEvent.getEventType()) {
+            case EVALUATION_RELOAD:
+                assertNotNull(statusEvent.extractPayload());
+                assertThat(statusEvent.extractPayload(), instanceOf(List.class)); // Fail the test if the payload has the wrong type
+                map.merge(name, 1L, Long::sum);
+                latch.countDown();
+                break;
+            case EVALUATION_CHANGE:
+            case EVALUATION_REMOVE:
+                assertNotNull(statusEvent.extractPayload());
+                assertThat(statusEvent.extractPayload(), instanceOf(Evaluation.class));
+                map.merge(name, 1L, Long::sum);
+                latch.countDown();
+                break;
+            case SSE_START:
+            case SSE_END:
+                map.merge(name, 1L, Long::sum);
+                latch.countDown();
+                break;
+
+            default:
+                map.merge("UNKNOWN", 1L, Long::sum);
+                break;
+        }
+    }
+
+    public Long getCountFor(StatusEvent.EVENT_TYPE event) {
+        return (Long) map.get(event.name());
+    }
+
+    public Long getCountForUnknown() {
+        return (Long) map.get("UNKNOWN");
+    }
+}

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.15'
+    implementation 'io.harness:ff-android-client-sdk:1.0.16'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/examples/GettingStarted/settings.gradle
+++ b/examples/GettingStarted/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 rootProject.name = "GettingStarted"


### PR DESCRIPTION
FFM-6144 - Android SDK Type casting

Adds additional hardening to event payloads + add new unit tests for CfClient. Also fixes an issue in RealServerSentEvent where if readUtf8Line() returned null on the SSE socket then the CPU would spin in a tight loop.

Testing
New unit tests + manual testing