### PR TITLE
FFM-4603 - Have to manually specify streamURL for the Android SDK

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
@@ -209,7 +209,9 @@ public class CfConfiguration {
          *
          * @param streamURL Base url for the SSE API.
          * @return Builder instance.
+         * @deprecated If streamUrl is not given then stream URL will now be automatically derived from baseUrl
          */
+        @Deprecated
         public Builder streamUrl(String streamURL) {
 
             this.streamURL = streamURL;
@@ -347,7 +349,7 @@ public class CfConfiguration {
 
             if (streamEnabled && (streamURL == null || streamURL.isEmpty())) {
 
-                streamURL = STREAM_URL;
+                streamURL = baseURL + "/stream";
             }
 
             final CfConfiguration cfConfiguration = new CfConfiguration(

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -86,11 +86,11 @@ public class CfClientTest {
             final int delayMs = 100;
             int maxWaitRemainingTime = (timeoutInSeconds*1000) / delayMs;
             while (!calledMap.containsKey(url) && maxWaitRemainingTime > 0) {
+                System.out.println("Waiting for connection to " + url);
                 Thread.sleep(delayMs);
                 maxWaitRemainingTime--;
             }
             if (maxWaitRemainingTime == 0) {
-                System.out.println("Waiting for connection to " + url);
                 fail("Timed out");
             } else {
                 System.out.println("Got a connection to " + url);


### PR DESCRIPTION
FFM-4603 - Have to manually specify streamURL for the Android SDK

What
Deprecate stream url and drive stream endpoint from base url.

Why
We should remain consistent with other SDKs

Testing
Added new unit tests to check stream endpoint connects when streamUrl is not given