### PR TITLE
FFM-6396 - Android/Flutter SDK: Can't initialise SDK without Target Identifier

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.0.16"
+        versionName "1.0.17"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.16"
+    PUBLISH_VERSION = "1.0.17"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,0 +1,5 @@
+package io.harness.cfsdk;
+
+public class AndroidSdkVersion {
+    public static final String ANDROID_SDK_VERSION = "1.0.17";
+}

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -517,6 +517,8 @@ public class CfClient implements Destroyable {
             return;
         }
 
+        setTargetDefaults(target);
+
         try {
 
             executor.execute(() -> {
@@ -604,6 +606,18 @@ public class CfClient implements Destroyable {
             }
 
             destroy();
+        }
+    }
+
+    private void setTargetDefaults(Target target) {
+        if ((target.getIdentifier() == null || target.getIdentifier().isEmpty())
+                && target.getName() == null || target.getName().isEmpty()) {
+            target.identifier("Default_Android_SDK_Target");
+            target.name("Default Android SDK Target");
+        }
+
+        if (target.getIdentifier() == null || target.getIdentifier().isEmpty()) {
+            target.identifier(target.getName());
         }
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -611,9 +611,8 @@ public class CfClient implements Destroyable {
 
     private void setTargetDefaults(Target target) {
         if ((target.getIdentifier() == null || target.getIdentifier().isEmpty())
-                && target.getName() == null || target.getName().isEmpty()) {
-            target.identifier("Default_Android_SDK_Target");
-            target.name("Default Android SDK Target");
+                && (target.getName() == null || target.getName().isEmpty())) {
+            throw new IllegalArgumentException("Target identifier and name are both missing");
         }
 
         if (target.getIdentifier() == null || target.getIdentifier().isEmpty()) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
@@ -1,5 +1,7 @@
 package io.harness.cfsdk.cloud;
 
+import java.util.Locale;
+
 import io.harness.cfsdk.cloud.core.api.DefaultApi;
 import io.harness.cfsdk.cloud.core.client.ApiClient;
 import io.harness.cfsdk.cloud.core.client.ApiException;
@@ -135,8 +137,11 @@ public class Cloud implements ICloud {
             authToken = defaultApi.authenticate(authenticationRequest).getAuthToken();
             this.tokenProvider.addToken(this.key, authToken);
         } catch (ApiException e) {
+            if (e.getCode() == 403) {
+                String message = String.format(Locale.US,"API, Authentication denied: message=%s httpCode=%d", e.getMessage(), e.getCode());
+                throw new RuntimeException(message, e);
+            }
             this.authToken = this.tokenProvider.getToken(this.key);
-
         } finally {
             apiClient.addDefaultHeader("Authorization", "Bearer " + authToken);
             this.authInfo = authResponseDecoder.extractInfo(authToken);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -1,6 +1,8 @@
 package io.harness.cfsdk.cloud.analytics;
 
 
+import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -263,7 +265,7 @@ public class AnalyticsPublisherService {
             setMetricsAttributes(metricsData, TARGET_ATTRIBUTE, entry.getKey().getTarget());
             setMetricsAttributes(metricsData, SDK_TYPE, CLIENT);
             setMetricsAttributes(metricsData, SDK_LANGUAGE, "android");
-            setMetricsAttributes(metricsData, SDK_VERSION, "1.0.16");
+            setMetricsAttributes(metricsData, SDK_VERSION, ANDROID_SDK_VERSION);
 
             metrics.addMetricsDataItem(metricsData);
         }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -1,5 +1,7 @@
 package io.harness.cfsdk.cloud.analytics;
 
+import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
+
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 
@@ -29,7 +31,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
             ApiClient apiClient = metricsAPI.getApiClient();
             apiClient.setBasePath(config.getEventURL());
             apiClient.addDefaultHeader("Authorization", "Bearer " + authToken);
-            apiClient.setUserAgent("android 1.0.16");
+            apiClient.setUserAgent("android " + ANDROID_SDK_VERSION);
             String hostname = "UnknownHost";
 
             try {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
@@ -1,5 +1,7 @@
 package io.harness.cfsdk.cloud.factories;
 
+import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
+
 import android.content.Context;
 
 import java.net.InetAddress;
@@ -92,7 +94,7 @@ public class CloudFactory implements ICloudFactory {
     public ApiClient apiClient() {
 
         final ApiClient apiClient = new ApiClient();
-        apiClient.setUserAgent("android 1.0.16");
+        apiClient.setUserAgent("android " + ANDROID_SDK_VERSION);
         String hostname = "UnknownHost";
         try {
 

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.16'
+    implementation 'io.harness:ff-android-client-sdk:1.0.17'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
FFM-6396 - Android/Flutter SDK: Can't initialise SDK without Target Identifier

What
Validate and check target for null or empty identifiers and set to name. If neither name or id are given and set to some default values. SDK hangs if it gets a 403 back on auth and doesn't report any error in the logs - so check for authentication failures and throw an exception instead of continuing

Why
Passing in a null identifier in the target causes auth endpoint to fail and return 403, which internally sets authInfo to null

Testing
Tested manually with GettingStarted example