### PR TITLE
FFM-6395 Return early if authentication or empty target ID encountered

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.0.17"
+        versionName "1.0.18"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.17"
+    PUBLISH_VERSION = "1.0.18"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.0.17";
+    public static final String ANDROID_SDK_VERSION = "1.0.18";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -525,6 +525,7 @@ public class CfClient implements Destroyable {
             if (authCallback != null) {
                 authCallback.authorizationSuccess(null, result);
             }
+            return;
         }
         try {
 
@@ -556,6 +557,7 @@ public class CfClient implements Destroyable {
                     if (authCallback != null) {
                         authCallback.authorizationSuccess(null, result);
                     }
+                    return;
                 }
                 if (success) {
 

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.17'
+    implementation 'io.harness:ff-android-client-sdk:1.0.18'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'


### PR DESCRIPTION
# What
Yesterday we added two exception handling paths for
- IllegalArgumentException if user doesn't supply a target ID or name
- APIException is client authentication fails

This change adds return statements to both, so we don't invoke the callback again which results in an exception which crashes the user's app.

# Why
So we don't attempt to invoke the callback after already invoking it in an exception path

# Testing
Manual