### PR TITLE
FFM-6574 - Stream latest changes upon network reconnect

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.0.18"
+        versionName "1.0.19"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.18"
+    PUBLISH_VERSION = "1.0.19"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.0.18";
+    public static final String ANDROID_SDK_VERSION = "1.0.19";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -114,14 +114,14 @@ public class CfClient implements Destroyable {
                 CfLog.OUT.v(logTag, "SSE connection resumed, reloading all evaluations");
 
 
-                final List<Evaluation> evaluations = featureRepository.getAllEvaluations(
+                final List<Evaluation> resumedEvaluations = featureRepository.getAllEvaluations(
 
                         environmentID,
                         target.getIdentifier(),
                         cluster
                 );
 
-                statusEvent = new StatusEvent(statusEvent.getEventType(), evaluations);
+                statusEvent = new StatusEvent(statusEvent.getEventType(), resumedEvaluations);
 
 
             case SSE_END:
@@ -309,7 +309,7 @@ public class CfClient implements Destroyable {
                 CfLog.OUT.v(logTag, "Evaluations count: " + evaluations.size());
 
                 if (useStream) {
-
+                    final boolean isRescheduled = true;
                     startSSE(true);
 
                 } else {
@@ -597,8 +597,8 @@ public class CfClient implements Destroyable {
                         sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, evaluations));
 
                         if (useStream) {
-
-                            startSSE(false);
+                            final boolean isRescheduled = false;
+                            startSSE(isRescheduled);
                         } else {
 
                             evaluationPolling.start(this::reschedule);

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -108,6 +108,22 @@ public class CfClient implements Destroyable {
                 evaluationPolling.stop();
                 break;
 
+            case SSE_RESUME:
+
+                evaluationPolling.stop();
+                CfLog.OUT.v(logTag, "SSE connection resumed, reloading all evaluations");
+
+
+                final List<Evaluation> evaluations = featureRepository.getAllEvaluations(
+
+                        environmentID,
+                        target.getIdentifier(),
+                        cluster
+                );
+
+                statusEvent = new StatusEvent(statusEvent.getEventType(), evaluations);
+
+
             case SSE_END:
 
                 if (networkInfoProvider.isNetworkAvailable()) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -106,19 +106,6 @@ public class CfClient implements Destroyable {
             case SSE_START:
 
                 evaluationPolling.stop();
-
-                // This event fires when SSE begins but it also fires If we lose a connection to the stream
-                // (e.g. if internet connectivity is lost) and reconnect again - in that case we will miss any events that are emitted so
-                // reload all evaluations to ensure we are up to date as soon as connectivity is restored.
-                final List<Evaluation> reloadedEvaluations = featureRepository.getAllEvaluations(
-
-                        environmentID,
-                        target.getIdentifier(),
-                        cluster
-                );
-
-                sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, reloadedEvaluations));
-
                 break;
 
             case SSE_END:

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -294,7 +294,7 @@ public class CfClient implements Destroyable {
 
                 if (useStream) {
 
-                    startSSE();
+                    startSSE(true);
 
                 } else {
 
@@ -337,7 +337,7 @@ public class CfClient implements Destroyable {
         });
     }
 
-    private synchronized void startSSE() {
+    private synchronized void startSSE(boolean isRescheduled) {
 
         CfLog.OUT.v(logTag, "Start SSE");
 
@@ -345,7 +345,7 @@ public class CfClient implements Destroyable {
 
         if (config.isValid()) {
 
-            sseController.start(config, eventsListener);
+            sseController.start(config, eventsListener, isRescheduled);
         }
     }
 
@@ -582,7 +582,7 @@ public class CfClient implements Destroyable {
 
                         if (useStream) {
 
-                            startSSE();
+                            startSSE(false);
                         } else {
 
                             evaluationPolling.start(this::reschedule);

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -106,6 +106,19 @@ public class CfClient implements Destroyable {
             case SSE_START:
 
                 evaluationPolling.stop();
+
+                // This event fires when SSE begins but it also fires If we lose a connection to the stream
+                // (e.g. if internet connectivity is lost) and reconnect again - in that case we will miss any events that are emitted so
+                // reload all evaluations to ensure we are up to date as soon as connectivity is restored.
+                final List<Evaluation> reloadedEvaluations = featureRepository.getAllEvaluations(
+
+                        environmentID,
+                        target.getIdentifier(),
+                        cluster
+                );
+
+                sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, reloadedEvaluations));
+
                 break;
 
             case SSE_END:

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/OkSse.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/OkSse.java
@@ -64,7 +64,8 @@ public class OkSse {
 
             Request request,
             ServerSentEvent.Listener listener,
-            SSEAuthentication authentication
+            SSEAuthentication authentication,
+            Boolean IsRescheduled
     ) {
 
         RealServerSentEvent sse = new RealServerSentEvent(request, listener, authentication);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/OkSse.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/OkSse.java
@@ -65,11 +65,11 @@ public class OkSse {
             Request request,
             ServerSentEvent.Listener listener,
             SSEAuthentication authentication,
-            Boolean IsRescheduled
+            boolean isRescheduled
     ) {
 
         RealServerSentEvent sse = new RealServerSentEvent(request, listener, authentication);
-        sse.connect(client);
+        sse.connect(client, isRescheduled);
         return sse;
     }
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -30,7 +30,15 @@ public class SSEListener implements ServerSentEvent.Listener {
     @Override
     public void onOpen(ServerSentEvent serverSentEvent, Response response, boolean isRescheduled) {
         if (this.eventsListener != null) {
-
+            // SSE can be started from two entrypoints in CFClient:
+            // 1. initialize
+            // 2. reschedule
+            // So make sure the right event is sent depending on how SSE has been started.
+            if (isRescheduled) {
+                this.eventsListener.onEventReceived(
+                        new StatusEvent(StatusEvent.EVENT_TYPE.SSE_RESUME, serverSentEvent)
+                );
+            }
             this.eventsListener.onEventReceived(
                     new StatusEvent(StatusEvent.EVENT_TYPE.SSE_START, serverSentEvent)
             );

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -28,7 +28,7 @@ public class SSEListener implements ServerSentEvent.Listener {
     }
 
     @Override
-    public void onOpen(ServerSentEvent serverSentEvent, Response response) {
+    public void onOpen(ServerSentEvent serverSentEvent, Response response, boolean isRescheduled) {
         if (this.eventsListener != null) {
 
             this.eventsListener.onEventReceived(
@@ -36,6 +36,7 @@ public class SSEListener implements ServerSentEvent.Listener {
             );
         }
     }
+
 
     @Override
     public void onMessage(ServerSentEvent serverSentEvent, String id, String event, String message) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/ServerSentEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/ServerSentEvent.java
@@ -50,7 +50,7 @@ public interface ServerSentEvent {
          * @param sse      the instance of {@link ServerSentEvent}
          * @param response the response from the server after establishing the connection
          */
-        void onOpen(ServerSentEvent sse, Response response, Boolean isRescheduled);
+        void onOpen(ServerSentEvent sse, Response response, boolean isRescheduled);
 
         /**
          * Called every time a message is received.

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/ServerSentEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/ServerSentEvent.java
@@ -50,7 +50,7 @@ public interface ServerSentEvent {
          * @param sse      the instance of {@link ServerSentEvent}
          * @param response the response from the server after establishing the connection
          */
-        void onOpen(ServerSentEvent sse, Response response);
+        void onOpen(ServerSentEvent sse, Response response, Boolean isRescheduled);
 
         /**
          * Called every time a message is received.

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/model/StatusEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/model/StatusEvent.java
@@ -20,7 +20,8 @@ public class StatusEvent {
          */
         SSE_START,
         /**
-         * Realtime evaluation update has restarted after recovering from network failure. Has no payload.
+         * Realtime evaluation update has restarted after recovering from network failure.
+         * Will reload latest evaluations from server. Has no payload.
          */
         SSE_RESUME,
         /**

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/model/StatusEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/model/StatusEvent.java
@@ -20,6 +20,10 @@ public class StatusEvent {
          */
         SSE_START,
         /**
+         * Realtime evaluation update has restarted after recovering from network failure. Has no payload.
+         */
+        SSE_RESUME,
+        /**
          * Realtime evaluation update is stopped. Has no payload.
          */
         SSE_END,

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/SSEController.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/SSEController.java
@@ -20,7 +20,7 @@ public class SSEController implements SSEControlling {
     }
 
     @Override
-    public synchronized void start(SSEConfig config, EventsListener eventsListener) {
+    public synchronized void start(SSEConfig config, EventsListener eventsListener, boolean isRescheduled) {
 
         if (config != null && config.getAuthentication() != null) {
 
@@ -36,7 +36,8 @@ public class SSEController implements SSEControlling {
 
                     request,
                     new SSEListener(eventsListener),
-                    config.getAuthentication()
+                    config.getAuthentication(),
+                    isRescheduled
             );
         }
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/SSEControlling.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/SSEControlling.java
@@ -5,7 +5,7 @@ import io.harness.cfsdk.cloud.oksse.model.SSEConfig;
 
 public interface SSEControlling {
 
-    void start(SSEConfig config, EventsListener eventsListener);
+    void start(SSEConfig config, EventsListener eventsListener, boolean isRescheduled);
 
     void stop();
 }

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -17,6 +17,7 @@ import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATI
 import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATION_RELOAD;
 import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.EVALUATION_REMOVE;
 import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.SSE_END;
+import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.SSE_RESUME;
 import static io.harness.cfsdk.cloud.oksse.model.StatusEvent.EVENT_TYPE.SSE_START;
 
 import android.content.Context;
@@ -210,5 +211,20 @@ public class CfClientTest {
         assertEquals((Long) 1L, (Long) eventCounter.getCountFor(EVALUATION_RELOAD));
     }
 
+    @Test
+    public void sseResumeEventShouldSendCorrectPayload() throws InterruptedException {
+
+        CfLog.testModeOn();
+
+        final EventsListenerCounter eventCounter = new EventsListenerCounter(1);
+        final CfClient client = new CfClient();
+        client.registerEventsListener(eventCounter);
+
+        client.sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.SSE_RESUME, new Evaluation())); // invalid, will be filtered out
+        client.sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.SSE_RESUME, Collections.singletonList(new Evaluation()))); // valid
+        eventCounter.waitForAllEventsOrTimeout(30);
+
+        assertEquals((Long) 1L, (Long) eventCounter.getCountFor(SSE_RESUME));
+    }
 
 }

--- a/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedSSEController.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedSSEController.java
@@ -18,7 +18,7 @@ public class MockedSSEController implements SSEControlling {
     }
 
     @Override
-    public void start(SSEConfig config, EventsListener eventsListener) {
+    public void start(SSEConfig config, EventsListener eventsListener, boolean isRescheduled) {
 
         CfLog.OUT.v(logTag, "Start");
 

--- a/cfsdk/src/test/java/io/harness/cfsdk/utils/EventsListenerCounter.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/utils/EventsListenerCounter.java
@@ -58,6 +58,8 @@ public class EventsListenerCounter implements EventsListener {
                 latch.countDown();
                 break;
             case SSE_START:
+            case SSE_RESUME:
+
             case SSE_END:
                 map.merge(name, 1L, Long::sum);
                 latch.countDown();

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -195,6 +195,7 @@ Triggered event will have one of the following types:
 ```Java
 public enum EVENT_TYPE {
         SSE_START, 
+        SSE_RESUME
         SSE_END, 
         EVALUATION_CHANGE,
         EVALUATION_RELOAD
@@ -203,8 +204,9 @@ public enum EVENT_TYPE {
 Following table provides summary on possible event types and corresponding responses.
 
 | EVENT_TYPE        | Response          |         
-| -------------     |:-------:          |      
+|-------------------|:-------:          |      
 | SSE_START         | -                 |
+| SSE_RESUME        | -                 |
 | SSE_END           | -                 |
 | EVALUATION_CHANGE | `Evaluation`      | 
 | EVALUATION_RELOAD | `List<Evaluation>`|

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.18'
+    implementation 'io.harness:ff-android-client-sdk:1.0.19'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/examples/GettingStarted/settings.gradle
+++ b/examples/GettingStarted/settings.gradle
@@ -10,7 +10,6 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        mavenLocal()
     }
 }
 rootProject.name = "GettingStarted"

--- a/examples/example/build.gradle
+++ b/examples/example/build.gradle
@@ -8,8 +8,8 @@ android {
 
     defaultConfig {
         applicationId "io.harness.cfsdk.example"
-        minSdk 19
-        targetSdk 31
+        minSdkVersion 19
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
 

--- a/examples/example/build.gradle
+++ b/examples/example/build.gradle
@@ -4,19 +4,18 @@ plugins {
 }
 
 android {
-
-    compileSdkVersion 31
-    buildToolsVersion "30.0.3"
+    compileSdk 32
 
     defaultConfig {
-
-        applicationId "io.harness.cfsdk.example"
-        minSdkVersion 19
-        targetSdkVersion 31
+        applicationId "io.harness.cfsdk.gettingstarted"
+        minSdk 25
+        targetSdk 32
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        buildConfigField "String", "FF_FLAG_NAME", "\"${System.env.FF_FLAG_NAME}\""
+        buildConfigField "String", "FF_API_KEY", "\"${System.env.FF_API_KEY}\""
     }
 
     buildTypes {

--- a/examples/example/build.gradle
+++ b/examples/example/build.gradle
@@ -7,15 +7,13 @@ android {
     compileSdk 32
 
     defaultConfig {
-        applicationId "io.harness.cfsdk.gettingstarted"
-        minSdk 25
-        targetSdk 32
+        applicationId "io.harness.cfsdk.example"
+        minSdk 19
+        targetSdk 31
         versionCode 1
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        buildConfigField "String", "FF_FLAG_NAME", "\"${System.env.FF_FLAG_NAME}\""
-        buildConfigField "String", "FF_API_KEY", "\"${System.env.FF_API_KEY}\""
     }
 
     buildTypes {


### PR DESCRIPTION
# What
Previously If an application lost internet connectivity and during that period new events were streamed but missed; upon reconnecting the SDK would not get stream the latest events. This would result in incorrect flag evaluations as the cache would be out of date. 

This change introduces a new event `SSE_RESUME` which is emitted by the `SSEListener` class if it detects that the SSE service has been started in the context of `reschedule`.  The `CFClient` event listener will act upon the `SSE_RESUME` event by reloading all evaluations from the server and updating all registered `EventListener`s with the change. 

# Why
So that a device that has temporarily lost internet connectivity has current evaluations without having to restart the application. 

# Testing
Manual using an emulator with example application with a single EventListener calling bool variation
1. Initialised client
2. Disabled emulator wifi/mobile internet
3. Change flag state
4. Enable emulator wifi 
5. 5 to 7 seconds later the registered event listener fired and showed the correct variation. 

A single unit test which follows @andybharness 's SSE_RELOAD pattern which does the same thing and verifies the SSE_RESUME event payload is valid

# Known issues
Upon network reconnection, it takes about 5 - 7 seconds for the Android SSE library to return a `200` response and begin streaming. I chatted with @conormurray95 and @davejohnston and they confirmed this is a quirk among different libraries/browsers etc. but which can be remedied in the future server-side. 