### PR TITLE
FFM-6713 - Android SDK - Evaluation functions not using cache

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.0.19"
+        versionName "1.0.20"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -60,4 +60,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.10.0'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
     testImplementation 'org.json:json:20180813'
+    testImplementation 'com.google.guava:guava:31.1-android'
 }

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.0.19"
+    PUBLISH_VERSION = "1.0.20"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.0.19";
+    public static final String ANDROID_SDK_VERSION = "1.0.20";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -142,7 +142,7 @@ public class CfClient implements Destroyable {
             case EVALUATION_CHANGE:
 
                 final Evaluation evaluation = statusEvent.extractPayload();
-                final Evaluation e = featureRepository.getEvaluation(
+                final Evaluation e = featureRepository.getEvaluationFromServer(
 
                         authInfo.getEnvironmentIdentifier(),
                         target.getIdentifier(),
@@ -150,8 +150,12 @@ public class CfClient implements Destroyable {
                         cluster
                 );
 
-                statusEvent = new StatusEvent(statusEvent.getEventType(), e);
-                notifyListeners(e);
+                if (e != null) {
+                    statusEvent = new StatusEvent(statusEvent.getEventType(), e);
+                    notifyListeners(e);
+                } else {
+                    CfLog.OUT.w(logTag, String.format("EVALUATION_CHANGE event failed to get evaluation for target '%s' from server", target.getIdentifier()));
+                }
 
                 break;
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -709,7 +709,7 @@ public class CfClient implements Destroyable {
      * @param defaultValue Default value to be used in case when evaluation is not found
      * @return Evaluation for a given id
      */
-    private <T> Evaluation getEvaluationById(
+    <T> Evaluation getEvaluationById(
 
             String evaluationId,
             String target,
@@ -948,5 +948,9 @@ public class CfClient implements Destroyable {
 
     void setNetworkInfoProvider(NetworkInfoProviding networkInfoProvider) {
         this.networkInfoProvider = networkInfoProvider;
+    }
+
+    void reset() {
+        unregister();
     }
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
@@ -90,7 +90,7 @@ public class Cloud implements ICloud {
             );
         } catch (ApiException e) {
 
-            CfLog.OUT.e(logTag, e.getMessage(), e);
+            CfLog.OUT.e(logTag, e.getMessage() + " - httpCode: " + e.getCode(), e);
         }
         return null;
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepository.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepository.java
@@ -6,6 +6,10 @@ import io.harness.cfsdk.cloud.core.model.Evaluation;
 
 public interface FeatureRepository {
 
+    /**
+     * Check cache first for evaluation, if not found then calls getEvaluationFromServer()
+     * Returns null if evaluation not found in cache nor on server.
+     */
     Evaluation getEvaluation(
 
             String environment,
@@ -13,6 +17,19 @@ public interface FeatureRepository {
             String evaluationId,
             String cluster
     );
+
+    /**
+     * Bypass the cache and go directly to the ff-server for the evaluation.
+     * If network is online and evaluation is found, local cache will be updated
+     */
+    default Evaluation getEvaluationFromServer(
+
+            String environment,
+            String target,
+            String evaluationId,
+            String cluster
+
+    ) { return null; }
 
     List<Evaluation> getAllEvaluations(
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
@@ -42,10 +42,13 @@ public class FeatureRepositoryImpl implements FeatureRepository {
             final String evaluationId,
             final String cluster
     ) {
-        if (networkInfoProvider.isNetworkAvailable()) {
+
+        Evaluation eval = cloudCache.getEvaluation(buildKey(environment, target), evaluationId);
+
+        if (eval == null && networkInfoProvider.isNetworkAvailable()) {
+            // Not in the cache, call out to the network for it
 
             ApiResponse apiResponse = this.featureService.getEvaluationForId(
-
                     evaluationId, target, cluster
             );
 
@@ -53,11 +56,11 @@ public class FeatureRepositoryImpl implements FeatureRepository {
 
                 final String env = buildKey(environment, target);
                 cloudCache.saveEvaluation(env, evaluationId, apiResponse.body());
-                return apiResponse.body();
+                eval = apiResponse.body();
             }
         }
 
-        return cloudCache.getEvaluation(buildKey(environment, target), evaluationId);
+        return eval;
     }
 
     @Override

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
@@ -42,10 +42,23 @@ public class FeatureRepositoryImpl implements FeatureRepository {
             final String evaluationId,
             final String cluster
     ) {
-
         Evaluation eval = cloudCache.getEvaluation(buildKey(environment, target), evaluationId);
 
-        if (eval == null && networkInfoProvider.isNetworkAvailable()) {
+        if (eval == null) {
+            eval = getEvaluationFromServer(environment, target, evaluationId, cluster);
+        }
+
+        return eval;
+    }
+
+    @Override
+    public Evaluation getEvaluationFromServer(
+        final String environment,
+        final String target,
+        final String evaluationId,
+        final String cluster) {
+
+        if (networkInfoProvider.isNetworkAvailable()) {
             // Not in the cache, call out to the network for it
 
             ApiResponse apiResponse = this.featureService.getEvaluationForId(
@@ -56,11 +69,11 @@ public class FeatureRepositoryImpl implements FeatureRepository {
 
                 final String env = buildKey(environment, target);
                 cloudCache.saveEvaluation(env, evaluationId, apiResponse.body());
-                eval = apiResponse.body();
+                return apiResponse.body();
             }
         }
 
-        return eval;
+        return null;
     }
 
     @Override

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -1,10 +1,14 @@
 package io.harness.cfsdk;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static io.harness.cfsdk.TestUtils.makeAuthResponse;
 import static io.harness.cfsdk.TestUtils.makeBasicEvaluationsListJson;
+import static io.harness.cfsdk.TestUtils.makeEmptyEvaluationsListJson;
 import static io.harness.cfsdk.TestUtils.makeFlagCreateEvent;
 import static io.harness.cfsdk.TestUtils.makeFlagDeleteEvent;
 import static io.harness.cfsdk.TestUtils.makeMockJsonResponse;
@@ -24,17 +28,22 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
+import com.google.common.util.concurrent.AtomicLongMap;
+
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Collections;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import io.harness.cfsdk.cloud.core.model.Evaluation;
 import io.harness.cfsdk.cloud.model.Target;
+import io.harness.cfsdk.cloud.network.NetworkInfoProviding;
 import io.harness.cfsdk.cloud.oksse.model.StatusEvent;
 import io.harness.cfsdk.logging.CfLog;
 import io.harness.cfsdk.mock.MockedCache;
@@ -50,34 +59,40 @@ import okhttp3.mockwebserver.RecordedRequest;
  */
 public class CfClientTest {
 
-    private static final String logTag = CfClientTest.class.getSimpleName();
+    private static final Target DUMMY_TARGET = new Target().identifier("anyone@anywhere.com").name("unit-test");;
 
     static class MockWebServerDispatcher extends Dispatcher {
+
+        public static final String AUTH_ENDPOINT = "/api/1.0/client/auth";
+        public static final String EVALUATION_ENDPOINT = "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations/anyone%40anywhere.com?cluster=1";
+        public static final String ALL_EVALUATIONS_ENDPOINT = "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations?cluster=1";
+        public static final String STREAM_ENDPOINT = "/api/1.0/stream?cluster=1";
+
         private final AtomicInteger version = new AtomicInteger(2);
-        private final Map<String, Boolean> calledMap = new ConcurrentHashMap<>();
+        protected final AtomicLongMap<String> calledMap = AtomicLongMap.create();
+
         @NonNull
         @Override
         public MockResponse dispatch(RecordedRequest request) {
 
             System.out.println("MOCK WEB SERVER GOT ------> " + request.getPath());
 
-            calledMap.put(request.getPath(), true);
+            calledMap.incrementAndGet(Objects.requireNonNull(request.getPath()));
 
             switch (Objects.requireNonNull(request.getPath())) {
-                case "/api/1.0/client/auth":
+                case AUTH_ENDPOINT:
                     return makeAuthResponse();
-                case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations?cluster=1":
+                case ALL_EVALUATIONS_ENDPOINT:
                     return makeMockJsonResponse(200, makeBasicEvaluationsListJson());
-                case "/api/1.0/stream?cluster=1":
+                case STREAM_ENDPOINT:
                     return makeMockStreamResponse(200,
                             makeTargetSegmentCreateEvent("anyone@anywhere.com", version.getAndIncrement()),
                             makeTargetSegmentPatchEvent("anyone@anywhere.com", version.getAndIncrement()),
                             makeFlagCreateEvent("anyone@anywhere.com", version.getAndIncrement()),
                             makeFlagDeleteEvent("anyone@anywhere.com", version.getAndIncrement())
                     );
-                case "/api/1.0/client/env/00000000-0000-0000-0000-000000000000/target/anyone%40anywhere.com/evaluations/anyone%40anywhere.com?cluster=1":
-                    return  makeMockJsonResponse(200, makeSingleEvaluationJson());
-
+                case EVALUATION_ENDPOINT:
+                    return makeMockJsonResponse(200, makeSingleEvaluationJson());
             }
 
             throw new UnsupportedOperationException("ERROR: url not mapped " + request.getPath());
@@ -97,6 +112,54 @@ public class CfClientTest {
                 System.out.println("Got a connection to " + url);
             }
         }
+
+        public int getUrlAccessCount(String url) {
+            return (int) calledMap.get(url);
+        }
+
+    }
+
+    static class EvalEndpointDispatcher_WithCustomHttpCode_AndEmptyEvalList extends CfClientTest.MockWebServerDispatcher {
+
+        private final int httpCodeForEvaluationEndpoint;
+        EvalEndpointDispatcher_WithCustomHttpCode_AndEmptyEvalList(int httpCodeForEvaluationEndpoint) {
+            this.httpCodeForEvaluationEndpoint = httpCodeForEvaluationEndpoint;
+        }
+
+        @NonNull @Override
+        public MockResponse dispatch(RecordedRequest request) {
+            if (EVALUATION_ENDPOINT.equals(request.getPath())) {
+                calledMap.incrementAndGet(Objects.requireNonNull(request.getPath()));
+                return makeMockJsonResponse(httpCodeForEvaluationEndpoint, makeSingleEvaluationJson("testFlag", "boolean", "true", "anyone@anywhere.com"));
+            } else if (ALL_EVALUATIONS_ENDPOINT.equals(request.getPath())) {
+                calledMap.incrementAndGet(Objects.requireNonNull(request.getPath()));
+                return makeMockJsonResponse(200, makeEmptyEvaluationsListJson());
+            }
+            return super.dispatch(request);
+        }
+    }
+
+    static class EvalEndpointDispatcher_ForCacheMiss extends EvalEndpointDispatcher_WithCustomHttpCode_AndEmptyEvalList {
+        EvalEndpointDispatcher_ForCacheMiss() {
+            super(200);
+        }
+    }
+
+    static class EvalEndpointDispatcher_ReturnsHttp400 extends EvalEndpointDispatcher_WithCustomHttpCode_AndEmptyEvalList {
+        EvalEndpointDispatcher_ReturnsHttp400() {
+            super(400);
+        }
+    }
+
+    static class EvalEndpointDispatcher_ReturnsHttp500 extends EvalEndpointDispatcher_WithCustomHttpCode_AndEmptyEvalList {
+        EvalEndpointDispatcher_ReturnsHttp500() {
+            super(500);
+        }
+    }
+
+    @Before
+    public void beforeEach() {
+        CfLog.testModeOn();
     }
 
     @Test
@@ -123,27 +186,24 @@ public class CfClientTest {
 
     private void testShouldConnectToWebServerSteamTest(BiFunction<String, Integer, CfConfiguration> configCallback) throws Exception {
 
-        CfLog.testModeOn();
-
         final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
         try (MockWebServer mockSvr = new MockWebServer()) {
             mockSvr.setDispatcher(dispatcher);
             mockSvr.start();
 
             final CfClient client = new CfClient();
-            client.setNetworkInfoProvider(new MockedNetworkInfoProvider());
+            client.setNetworkInfoProvider(MockedNetworkInfoProvider.create());
 
             final CfConfiguration config = configCallback.apply(mockSvr.getHostName(), mockSvr.getPort());
+            client.setNetworkInfoProvider(MockedNetworkInfoProvider.create());
 
-            client.setNetworkInfoProvider(new MockedNetworkInfoProvider());
-            final Target target = new Target().identifier("anyone@anywhere.com").name("unit-test");
             final Context mockContext = mock(Context.class);
 
             client.initialize(
                     mockContext,
                     "dummykey",
                     config,
-                    target,
+                    DUMMY_TARGET,
                     new MockedCache()
             );
 
@@ -154,15 +214,13 @@ public class CfClientTest {
     @Test
     public void testRegisterEventsListener() throws Exception {
 
-        CfLog.testModeOn();
-
         try (MockWebServer mockSvr = new MockWebServer()) {
             mockSvr.setDispatcher(new MockWebServerDispatcher());
             mockSvr.start();
 
             final EventsListenerCounter eventCounter = new EventsListenerCounter(7); // Make sure this number matches assertions total below
             final CfClient client = new CfClient();
-            client.setNetworkInfoProvider(new MockedNetworkInfoProvider());
+            client.setNetworkInfoProvider(MockedNetworkInfoProvider.create());
             client.registerEventsListener(eventCounter);
 
             final CfConfiguration config = CfConfiguration.builder()
@@ -172,14 +230,13 @@ public class CfClientTest {
                     .enableStream(true)
                     .build();
 
-            final Target target = new Target().identifier("anyone@anywhere.com").name("unit-test");
             final Context mockContext = mock(Context.class);
 
             client.initialize(
                     mockContext,
                     "dummykey",
                     config,
-                    target,
+                    DUMMY_TARGET,
                     new MockedCache()
             );
 
@@ -198,8 +255,6 @@ public class CfClientTest {
     @Test
     public void evaluationReloadEventShouldSendCorrectPayload() throws InterruptedException {
 
-        CfLog.testModeOn();
-
         final EventsListenerCounter eventCounter = new EventsListenerCounter(1);
         final CfClient client = new CfClient();
         client.registerEventsListener(eventCounter);
@@ -214,8 +269,6 @@ public class CfClientTest {
     @Test
     public void sseResumeEventShouldSendCorrectPayload() throws InterruptedException {
 
-        CfLog.testModeOn();
-
         final EventsListenerCounter eventCounter = new EventsListenerCounter(1);
         final CfClient client = new CfClient();
         client.registerEventsListener(eventCounter);
@@ -225,6 +278,157 @@ public class CfClientTest {
         eventCounter.waitForAllEventsOrTimeout(30);
 
         assertEquals((Long) 1L, (Long) eventCounter.getCountFor(SSE_RESUME));
+    }
+
+    /*
+     * Set network off (MockedNetworkInfoProvider.createWithNetworkOff())
+     * Manually pre-populate cache (since getAllEvaluations won't be called)
+     * Get some boolean variations
+     * Assert no network calls are done (checking counters in MockWebServerDispatcher)
+     * Assert cache was used (checking counters in MockedCache)
+     */
+    @Test
+    public void shouldGetFlag_FromCacheAlways_WhenNetworkOffline() throws Exception {
+        final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
+        final MockedCache cache = new MockedCache();
+
+        cache.saveEvaluation("Production_anyone@anywhere.com", "anyone@anywhere.com", new Evaluation().value("true"));
+
+        runEvaluation(dispatcher, cache, MockedNetworkInfoProvider.createWithNetworkOff(), client -> {
+            for (int i = 0; i < 60; i++) {
+                boolean eval = client.boolVariation("anyone@anywhere.com", false);
+                assertTrue(eval);
+            }
+        });
+
+        assertEquals(0, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
+        assertEquals(60, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
+
+    }
+
+    /*
+     * Same as above, but with network on (MockedNetworkInfoProvider.create())
+     */
+    @Test
+    public void shouldGetFlag_FromCacheAlways_WhenNetworkOnline() throws Exception {
+        final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
+        final MockedCache cache = new MockedCache();
+
+        runEvaluation(dispatcher, cache, MockedNetworkInfoProvider.create(), client -> {
+            for (int i = 0; i < 60; i++) {
+                boolean eval = client.boolVariation("anyone@anywhere.com", false);
+                assertTrue(eval);
+            }
+        });
+
+        assertEquals(0, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
+        assertEquals(60, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
+    }
+
+    /*
+     * First check in cache and return null (empty MockedCache)
+     * Evaluation endpoint API should be called (MockedNetworkInfoProvider)
+     * Result should be saved in cache
+     */
+    @Test
+    public void shouldGetEvaluation_FromNetwork_WhenNotInCache() throws Exception {
+        final MockWebServerDispatcher dispatcher = new EvalEndpointDispatcher_ForCacheMiss();
+        final MockedCache cache = new MockedCache();
+
+        runEvaluation(dispatcher, cache, MockedNetworkInfoProvider.create(), client -> {
+
+            Evaluation eval = client.getEvaluationById("anyone@anywhere.com", "anyone@anywhere.com", false);
+            assertNotNull(eval);
+            assertEquals("testFlag", eval.getFlag());
+            assertEquals("anyone@anywhere.com", eval.getIdentifier());
+            assertEquals("true", eval.getValue());
+        });
+
+        assertEquals(1, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
+        assertEquals(0, cache.getCacheHitCountForEvaluation("anyonee@anywhere.com"));
+        assertEquals(1, cache.getCacheSavedCountForEvaluation("anyone@anywhere.com"));
+    }
+
+    /*
+     * First check in cache and return null (empty MockedCache)
+     * Evaluation endpoint API should be called and return 400 (MockedNetworkInfoProvider)
+     * Default value should be served
+     */
+    @Test
+    public void shouldGetEvaluation_WithDefaultValue_WhenNotInCache_AndServerReturns400() throws Exception {
+        final MockWebServerDispatcher dispatcher = new EvalEndpointDispatcher_ReturnsHttp400();
+        final MockedCache cache = new MockedCache();
+        final String DEFAULT_VALUE = "false";
+
+        runEvaluation(dispatcher, cache, MockedNetworkInfoProvider.create(), client -> {
+
+            Evaluation eval = client.getEvaluationById("anyone@anywhere.com", "anyone@anywhere.com", DEFAULT_VALUE);
+            assertNotNull(eval);
+            assertEquals("anyone@anywhere.com", eval.getFlag());
+            assertEquals(DEFAULT_VALUE, eval.getValue());
+        });
+
+        assertEquals(1, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
+        assertEquals(0, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
+        assertEquals(0, cache.getCacheSavedCountForEvaluation("anyone@anywhere.com"));
+    }
+
+    /*
+     * Same as above, except evaluation endpoint API should be called and return 500
+     */
+    @Test
+    public void shouldGetEvaluation_WithDefaultValue_WhenNotInCache_AndServerReturns500() throws Exception {
+        final MockWebServerDispatcher dispatcher = new EvalEndpointDispatcher_ReturnsHttp500();
+        final MockedCache cache = new MockedCache();
+        final String DEFAULT_VALUE = "false";
+
+        runEvaluation(dispatcher, cache, MockedNetworkInfoProvider.create(), client -> {
+
+            Evaluation eval = client.getEvaluationById("anyone@anywhere.com", "anyone@anywhere.com", DEFAULT_VALUE);
+            assertNotNull(eval);
+            assertEquals("anyone@anywhere.com", eval.getFlag());
+            assertEquals(DEFAULT_VALUE, eval.getValue());
+        });
+
+        assertEquals(1, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
+        assertEquals(0, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
+        assertEquals(0, cache.getCacheSavedCountForEvaluation("anyone@anywhere.com"));
+    }
+
+    private void runEvaluation(MockWebServerDispatcher dispatcher, MockedCache cache, NetworkInfoProviding networkInfoProvider, Consumer<CfClient> callback) throws Exception {
+
+        try (MockWebServer mockSvr = new MockWebServer()) {
+            mockSvr.setDispatcher(dispatcher);
+            mockSvr.start();
+
+            final CfClient client = CfClient.getInstance();
+            client.reset();
+            client.setNetworkInfoProvider(networkInfoProvider);
+
+            final CfConfiguration config = CfConfiguration.builder()
+                    .baseUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                    .eventUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                    .enableAnalytics(false)
+                    .enableStream(false)
+                    .build();
+
+            final Context mockContext = mock(Context.class);
+            final CountDownLatch authLatch = new CountDownLatch(1);
+
+            client.initialize(
+                    mockContext,
+                    "dummykey",
+                    config,
+                    DUMMY_TARGET,
+                    cache, (authInfo, result) -> authLatch.countDown()
+            );
+
+            assertTrue(authLatch.await(30, TimeUnit.SECONDS));
+            assertEquals(0, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
+
+            callback.accept(client);
+        }
+
     }
 
 }

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -164,7 +164,7 @@ public class CfClientTest {
 
     @Test
     public void shouldConnectToWebServerWithAbsoluteStreamUrl() throws Exception {
-        testShouldConnectToWebServerSteamTest((host, port) -> CfConfiguration.builder()
+        testShouldConnectToWebServerStreamTest((host, port) -> CfConfiguration.builder()
                 .baseUrl(makeServerUrl(host, port))
                 .eventUrl(makeServerUrl(host, port))
                 .streamUrl(makeServerUrl(host, port) + "/stream") // make sure we're still backwards compatible
@@ -175,7 +175,7 @@ public class CfClientTest {
 
     @Test
     public void shouldConnectToWebServerWithoutStreamUrl() throws Exception {
-        testShouldConnectToWebServerSteamTest((host, port) -> CfConfiguration.builder()
+        testShouldConnectToWebServerStreamTest((host, port) -> CfConfiguration.builder()
                 .baseUrl(makeServerUrl(host, port))
                 .eventUrl(makeServerUrl(host, port))
                 // streamUrl not specified
@@ -184,7 +184,7 @@ public class CfClientTest {
                 .build());
     }
 
-    private void testShouldConnectToWebServerSteamTest(BiFunction<String, Integer, CfConfiguration> configCallback) throws Exception {
+    private void testShouldConnectToWebServerStreamTest(BiFunction<String, Integer, CfConfiguration> configCallback) throws Exception {
 
         final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
         try (MockWebServer mockSvr = new MockWebServer()) {
@@ -345,7 +345,7 @@ public class CfClientTest {
         });
 
         assertEquals(1, dispatcher.getUrlAccessCount(MockWebServerDispatcher.EVALUATION_ENDPOINT));
-        assertEquals(0, cache.getCacheHitCountForEvaluation("anyonee@anywhere.com"));
+        assertEquals(0, cache.getCacheHitCountForEvaluation("anyone@anywhere.com"));
         assertEquals(1, cache.getCacheSavedCountForEvaluation("anyone@anywhere.com"));
     }
 

--- a/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
@@ -34,13 +34,23 @@ public class TestUtils {
 
     static String makeBasicEvaluationsListJson() {
         final List<Evaluation> list = new ArrayList<>();
-        list.add(new Evaluation().flag("testFlag").kind("fixme").value("on").identifier("anyone@anywhere.com"));
+        list.add(new Evaluation().flag("testFlag").kind("boolean").value("true").identifier("anyone@anywhere.com"));
 
         return new Gson().toJson(list);
     }
 
+    static String makeEmptyEvaluationsListJson() {
+        final List<Evaluation> list = new ArrayList<>();
+        return new Gson().toJson(list);
+    }
+
+    static String makeSingleEvaluationJson(String flag, String kind, String value, String id) {
+        final Evaluation eval = new Evaluation().flag(flag).kind(kind).value(value).identifier(id);
+        return new Gson().toJson(eval);
+    }
+
     static String makeSingleEvaluationJson() {
-        final Evaluation eval = new Evaluation().flag("testFlag").kind("fixme").value("on").identifier("anyone@anywhere.com");
+        final Evaluation eval = new Evaluation().flag("testFlag").kind("boolean").value("true").identifier("anyone@anywhere.com");
         return new Gson().toJson(eval);
     }
 

--- a/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/TestUtils.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import io.harness.cfsdk.cloud.core.model.Evaluation;
 import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.SocketPolicy;
 
 public class TestUtils {
 
@@ -89,7 +90,8 @@ public class TestUtils {
                 .setResponseCode(httpCode)
                 .setBody(builder.toString())
                 .addHeader("Content-Type", "text/event-stream; charset=UTF-8")
-                .addHeader("Accept-Encoding", "identity");
+                .addHeader("Accept-Encoding", "identity")
+                .setSocketPolicy(SocketPolicy.KEEP_OPEN);
     }
 
     static String makeServerUrl(String host, int port) {

--- a/cfsdk/src/test/java/io/harness/cfsdk/cloud/analytics/AnalyticsManagerTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/cloud/analytics/AnalyticsManagerTest.java
@@ -26,7 +26,7 @@ public class AnalyticsManagerTest {
 
     {
 
-        timeout = 3000L;
+        timeout = 30_000L;
         logTag = AnalyticsManagerTest.class.getSimpleName();
     }
 
@@ -72,7 +72,7 @@ public class AnalyticsManagerTest {
 
                 if (System.currentTimeMillis() - start >= timeout) {
 
-                    Assert.fail("Timeout after 3 seconds");
+                    Assert.fail("Timeout after " + timeout);
                 }
 
             } catch (InterruptedException e) {
@@ -92,7 +92,7 @@ public class AnalyticsManagerTest {
 
                 if (System.currentTimeMillis() - start >= timeout) {
 
-                    Assert.fail("Timeout after 3 seconds");
+                    Assert.fail("Timeout after " + timeout);
                 }
 
             } catch (InterruptedException e) {

--- a/cfsdk/src/test/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImplTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImplTest.java
@@ -1,0 +1,25 @@
+package io.harness.cfsdk.cloud.repository;
+
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+import io.harness.cfsdk.cloud.cache.CloudCache;
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+import io.harness.cfsdk.mock.MockedNetworkInfoProvider;
+
+public class FeatureRepositoryImplTest {
+
+    @Test
+    public void getEvaluationShouldReturnNullWhenEvalNotInCacheNorNetwork() {
+
+        final CloudCache mockCache = mock(CloudCache.class);
+        final FeatureRepositoryImpl featureRepo = new FeatureRepositoryImpl(null, mockCache, MockedNetworkInfoProvider.createWithNetworkOff());
+
+        Evaluation eval = featureRepo.getEvaluation("dummyenv", "dummytarget", "featureid", "1");
+
+        assertNull(eval);
+
+    }
+}

--- a/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedCloudFactory.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedCloudFactory.java
@@ -22,7 +22,7 @@ public class MockedCloudFactory extends CloudFactory {
     @Override
     public NetworkInfoProviding networkInfoProvider(final Context context) {
 
-        return new MockedNetworkInfoProvider();
+        return MockedNetworkInfoProvider.create();
     }
 
     @Override

--- a/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedNetworkInfoProvider.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedNetworkInfoProvider.java
@@ -4,12 +4,23 @@ import io.harness.cfsdk.cloud.network.NetworkInfoProviding;
 
 public class MockedNetworkInfoProvider extends NetworkInfoProviding {
 
-    public MockedNetworkInfoProvider() {
+    private final boolean isNetworkAvailable;
+
+    private MockedNetworkInfoProvider(boolean isNetworkAvailable) {
+        this.isNetworkAvailable = isNetworkAvailable;
+    }
+
+    public static NetworkInfoProviding create() {
+        return new MockedNetworkInfoProvider(true);
+    }
+
+    public static NetworkInfoProviding createWithNetworkOff() {
+        return new MockedNetworkInfoProvider(false);
     }
 
     @Override
     public boolean isNetworkAvailable() {
 
-        return true;
+        return isNetworkAvailable;
     }
 }

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.material:material:1.6.0'
-    implementation 'io.harness:ff-android-client-sdk:1.0.19'
+    implementation 'io.harness:ff-android-client-sdk:1.0.20'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/examples/GettingStarted/settings.gradle
+++ b/examples/GettingStarted/settings.gradle
@@ -10,6 +10,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        mavenLocal()
     }
 }
 rootProject.name = "GettingStarted"


### PR DESCRIPTION
What
Fix FeatureRepositoryImpl to prefer cache, call out to network to get flag only if its not found in cache and network is available.

Why
The getEvaluation function is performing very poorly and causing excessive API callouts to the ff-server when it should be using the cache.

Testing
Several new unit tests added + manual