### PR TITLE
FFM-7037 - Add SDK info header

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -47,6 +47,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
             }
 
             apiClient.addDefaultHeader("Hostname", hostname);
+            apiClient.addDefaultHeader("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
             metricsAPI.setApiClient(apiClient);
         }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/factories/CloudFactory.java
@@ -105,6 +105,7 @@ public class CloudFactory implements ICloudFactory {
             CfLog.OUT.w(logTag, "Unable to get hostname");
         }
         apiClient.addDefaultHeader("Hostname", hostname);
+        apiClient.addDefaultHeader("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
         return apiClient;
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
@@ -16,6 +16,8 @@
 
 package io.harness.cfsdk.cloud.oksse;
 
+import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
@@ -74,7 +76,9 @@ class RealServerSentEvent implements ServerSentEvent {
                 .header("Accept", "text/event-stream")
                 .header("Cache-Control", "no-cache")
                 .header("API-Key", this.authentication.getApiToken())
-                .header("Authorization", "Bearer " + this.authentication.getAuthToken());
+                .header("Authorization", "Bearer " + this.authentication.getAuthToken())
+                .header("User-Agent", "android " + ANDROID_SDK_VERSION)
+                .header("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
 
         if (lastEventId != null) {
             requestBuilder.header("Last-Event-Id", lastEventId);


### PR DESCRIPTION
FFM-7037 - Add SDK info header

What
Add Harness-SDK-Info header to outbound HTTP connections

Why
Helps with diagnosing issues on the backend

Testing
Manual - tested with a proxy that logs headers