### PR TITLE
FFM-7037 - Fix HTTP header to use getEnvironmentIdentifier instead of getEnvironment

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
@@ -139,7 +139,7 @@ public class Cloud implements ICloud {
         this.authInfo = authResponseDecoder.extractInfo(authToken);
 
         if (authInfo != null) {
-            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironment());
+            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier());
             apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
         }
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -49,7 +49,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
 
             apiClient.addDefaultHeader("Hostname", hostname);
             apiClient.addDefaultHeader("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
-            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironment());
+            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier());
             apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
             metricsAPI.setApiClient(apiClient);
         }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
@@ -76,7 +76,7 @@ class RealServerSentEvent implements ServerSentEvent {
                 .header("Authorization", "Bearer " + this.authentication.getAuthToken())
                 .header("User-Agent", "android " + ANDROID_SDK_VERSION)
                 .header("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client")
-                .header("Harness-EnvironmentID", authInfo.getEnvironment())
+                .header("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier())
                 .header("Harness-AccountID", authInfo.getAccountID());
 
         if (lastEventId != null) {


### PR DESCRIPTION
FFM-7037 - Fix HTTP header to use getEnvironmentIdentifier instead of getEnvironment

What
Minor fix to a previous commit use the readable id instead of the hash in the HTTP header