### PR TITLE
(FFM-7955) Add pre-evaluation logic to android sdk

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/SSEListener.java
@@ -82,6 +82,17 @@ public class SSEListener implements ServerSentEvent.Listener {
             if ("flag".equals(domain)) {
                 // On creation or change of a flag we want to send a change event
                 if ("create".equals(eventType) || "patch".equals(eventType)) {
+                    // parse the actual evaluation sent in the sse event if there is one
+                    try {
+                        JSONObject evaluationJSON = new JSONObject(jsonObject.getString("evaluation"));
+                        evaluation.flag(evaluationJSON.getString("flag"));
+                        evaluation.identifier(evaluationJSON.getString("identifier"));
+                        evaluation.kind(evaluationJSON.getString("kind"));
+                        evaluation.value(evaluationJSON.getString("value"));
+                    } catch (Exception e) {
+                        // this will happen if the evaluations aren't sent down the stream with the event
+                        // it's not an error case so no need to log it
+                    }
                     statusEvent = new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_CHANGE, evaluation);
                 }
                 // On deletion of a flag we want to send a remove event

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepository.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepository.java
@@ -40,5 +40,7 @@ public interface FeatureRepository {
 
     void remove(String environment, String target, String evaluationId);
 
+    void save(String environment, String target, Evaluation evaluation);
+
     void clear();
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/repository/FeatureRepositoryImpl.java
@@ -142,6 +142,12 @@ public class FeatureRepositoryImpl implements FeatureRepository {
         this.cloudCache.removeEvaluation(buildKey(environment, target), evaluationId);
     }
 
+    @Override
+    public void save(String environment, String target, Evaluation evaluation) {
+        final String env = buildKey(environment, target);
+        cloudCache.saveEvaluation(env, evaluation.getFlag(), evaluation);
+    }
+
 
     @Override
     public void clear() {

--- a/cfsdk/src/main/java/io/harness/cfsdk/utils/CfUtils.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/utils/CfUtils.java
@@ -1,5 +1,9 @@
 package io.harness.cfsdk.utils;
 
+import static io.harness.cfsdk.utils.CfUtils.Text.isNotEmpty;
+
+import io.harness.cfsdk.cloud.core.model.Evaluation;
+
 /**
  * Various utils for the SDK.
  */
@@ -36,6 +40,21 @@ public class CfUtils {
         public static boolean isNotEmpty(String text) {
 
             return !isEmpty(text);
+        }
+    }
+
+    public static class EvaluationUtil {
+        private EvaluationUtil() {
+        }
+
+        /**
+         * Check if the Evaluation is valid.
+         *
+         * @param evaluation Evaluation to check.
+         * @return True == Evaluation has all fields populated.
+         */
+        public static boolean isEvaluationValid(Evaluation evaluation) {
+            return isNotEmpty(evaluation.getFlag()) && isNotEmpty(evaluation.getKind()) && isNotEmpty(evaluation.getIdentifier()) && isNotEmpty(evaluation.getValue());
         }
     }
 }

--- a/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedFeatureRepository.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/mock/MockedFeatureRepository.java
@@ -68,6 +68,16 @@ public class MockedFeatureRepository implements FeatureRepository {
     }
 
     @Override
+    public void save(
+
+            String environment,
+            String target,
+            Evaluation evaluation) {
+
+        mocks.put(evaluation.getFlag(), evaluation);
+    }
+
+    @Override
     public void clear() {
 
         mocks.clear();


### PR DESCRIPTION
**Changes**
If the flag evaluation is sent directly in the sse stream save it and don't query SaaS.
If the flag evaluation isn't sent then query SaaS for the updated value as normal.