### PR TITLE
FFM-8551 - Android SDK - Insecure TLS/SSL trust manager lint warning

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -10,9 +10,9 @@ android {
     defaultConfig {
 
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 12
-        versionName "1.1.0"
+        versionName "1.1.1"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.1.0"
+    PUBLISH_VERSION = "1.1.1"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.1.0";
+    public static final String ANDROID_SDK_VERSION = "1.1.1";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/core/client/ApiClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/core/client/ApiClient.java
@@ -1301,28 +1301,8 @@ public class ApiClient {
             TrustManager[] trustManagers;
             HostnameVerifier hostnameVerifier;
             if (!verifyingSsl) {
-                trustManagers = new TrustManager[]{
-                        new X509TrustManager() {
-                            @Override
-                            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-                            }
-
-                            @Override
-                            public X509Certificate[] getAcceptedIssuers() {
-                                return new X509Certificate[]{};
-                            }
-                        }
-                };
-                hostnameVerifier = new HostnameVerifier() {
-                    @Override
-                    public boolean verify(String hostname, SSLSession session) {
-                        return true;
-                    }
-                };
+                // FFM-8551
+                throw new UnsupportedOperationException("TLS should not be disabled");
             } else {
                 TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
 


### PR DESCRIPTION
FFM-8551 - Android SDK - Insecure TLS/SSL trust manager lint warning on Android

What
Remove OpenAPI code which contains logic to disable SSL by creating empty truststores. We don't use this code. It is automatically generated by OpenAPI and there doesn't seem to be any options to disable it, upgrading won't help either so we will remove it and replace it with an exception if called.

Why
The Gradle lint task is flagging this code as insecure with:

`checkClientTrusted is empty, which could cause insecure network traffic due to trusting arbitrary TLS/SSL certificates presented by peers`

Testing
Manual smoke testing