### PR TITLE
FFM-8686 Only include accountID if it is present in the JWT, i.e., th…

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.1.1"
+        versionName "1.1.2"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.1.1"
+    PUBLISH_VERSION = "1.1.2"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.1.1";
+    public static final String ANDROID_SDK_VERSION = "1.1.2";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
@@ -139,7 +139,10 @@ public class Cloud implements ICloud {
         this.authInfo = authResponseDecoder.extractInfo(authToken);
 
         if (authInfo != null) {
-            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironment());
+            String environmentHeader = authInfo.getEnvironmentTrackingHeader();
+
+            apiClient.addDefaultHeader("Harness-EnvironmentID", environmentHeader);
+
             String accountID = authInfo.getAccountID();
             if (accountID != null) {
                 apiClient.addDefaultHeader("Harness-AccountID", accountID);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/Cloud.java
@@ -105,7 +105,7 @@ public class Cloud implements ICloud {
     public boolean isInitialized() {
 
         return this.authToken != null && this.authInfo != null &&
-                this.authInfo.getEnvironmentIdentifier() != null;
+                this.authInfo.getEnvironment() != null;
     }
 
     @Override
@@ -139,8 +139,11 @@ public class Cloud implements ICloud {
         this.authInfo = authResponseDecoder.extractInfo(authToken);
 
         if (authInfo != null) {
-            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier());
-            apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
+            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironment());
+            String accountID = authInfo.getAccountID();
+            if (accountID != null) {
+                apiClient.addDefaultHeader("Harness-AccountID", accountID);
+            }
         }
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -49,8 +49,10 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
 
             apiClient.addDefaultHeader("Hostname", hostname);
             apiClient.addDefaultHeader("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
-            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier());
-            apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
+            apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentTrackingHeader());
+            if (authInfo.getAccountID() != null) {
+                apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
+            }
             metricsAPI.setApiClient(apiClient);
         }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/DefaultMetricsApiFactoryRecipe.java
@@ -50,6 +50,7 @@ public class DefaultMetricsApiFactoryRecipe implements MetricsApiFactoryRecipe {
             apiClient.addDefaultHeader("Hostname", hostname);
             apiClient.addDefaultHeader("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client");
             apiClient.addDefaultHeader("Harness-EnvironmentID", authInfo.getEnvironmentTrackingHeader());
+            // Relay Proxy does not include the accountID
             if (authInfo.getAccountID() != null) {
                 apiClient.addDefaultHeader("Harness-AccountID", authInfo.getAccountID());
             }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/model/AuthInfo.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/model/AuthInfo.java
@@ -46,6 +46,13 @@ public class AuthInfo {
         return environmentIdentifier;
     }
 
+    public String getEnvironmentTrackingHeader() {
+        if (environmentIdentifier == null) {
+            return environment;
+        }
+        return environmentIdentifier;
+    }
+
     public String getAccountID() {
         return accountID;
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/oksse/RealServerSentEvent.java
@@ -76,8 +76,12 @@ class RealServerSentEvent implements ServerSentEvent {
                 .header("Authorization", "Bearer " + this.authentication.getAuthToken())
                 .header("User-Agent", "android " + ANDROID_SDK_VERSION)
                 .header("Harness-SDK-Info", "Android " + ANDROID_SDK_VERSION + " Client")
-                .header("Harness-EnvironmentID", authInfo.getEnvironmentIdentifier())
-                .header("Harness-AccountID", authInfo.getAccountID());
+                .header("Harness-EnvironmentID", authInfo.getEnvironmentTrackingHeader());
+
+        // Relay Proxy does not include the accountID
+        if (authInfo.getAccountID() != null) {
+            requestBuilder.header("Harness-AccountID", authInfo.getAccountID());
+        }
 
         if (lastEventId != null) {
             requestBuilder.header("Last-Event-Id", lastEventId);


### PR DESCRIPTION
# What
- When the ff relay proxy is being used, the accountID is not currently present as a claim in the auth JWT. If the accountID is not in the claim, it will be `null`.  While this doesn't cause any issues in the SDK, we don't need to send it and the null value could cause noise in the resultant dashboards.
- `getEnvironmentIdentifier` was being used to determine if the SDK was initialised, e.g. `dev` or `prod` - the Relay Proxy doesn't send this, and so when the proxy was being used, the SDK would fail to start. This changes it to `getEnvironment` which returns the environment UUID

# Testing
Tested with Relay Proxy latest version, and without. 

