### PR TITLE
FFM-9445 Emit `EVALUATION_RELOADED` on polling intervals

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -12,7 +12,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
-        versionName "1.1.3"
+        versionName "1.1.4"
 
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -35,7 +35,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.1.3"
+    PUBLISH_VERSION = "1.1.4"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.1.3";
+    public static final String ANDROID_SDK_VERSION = "1.1.4";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -336,6 +336,9 @@ public class CfClient implements Destroyable {
 
                 CfLog.OUT.v(logTag, "Evaluations count: " + evaluations.size());
 
+                sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, evaluations));
+
+
                 if (useStream) {
                     final boolean isRescheduled = true;
                     startSSE(true);

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -336,6 +336,8 @@ public class CfClient implements Destroyable {
 
                 CfLog.OUT.v(logTag, "Evaluations count: " + evaluations.size());
 
+                // Notify users that evaluations have been reloaded. This happens first on client init,
+                // then if polling is enabled, on each interval.
                 sendEvent(new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, evaluations));
 
 


### PR DESCRIPTION
# What
Emits the `EVALUATION_RELOADED` event to users on client init, and on each polling interval

# Why
So the `EVALUATION_RELOADED` event is fired when evaluations are reloaded

# Testing
Manual with sample app