### PR TITLE
[FFM-9500] - Set scanBuildEnv to off

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,10 +26,9 @@ allprojects {
     apply plugin: 'org.owasp.dependencycheck'
 
       dependencyCheck {
-        scanBuildEnv = true
         format = "JSON"
         analyzers {
-            // full list https://github.com/dependency-check/dependency-check-gradle/blob/main/src/main/groovy/org/owasp/dependencycheck/gradle/extension/AnalyzerExtension.groovy
+            // full list https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html
             nuspecEnabled = false
             assemblyEnabled = false
             msbuildEnabled = false


### PR DESCRIPTION
[FFM-9500] - Set scanBuildEnv to off

What
Remove scanBuildEnv as its bringing in more JARs than we need to scan.

Why
We're seeing a lot of false-positives reported in STO that relate to build artifacts

[FFM-9500]: https://harness.atlassian.net/browse/FFM-9500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ