### PR TITLE
[FFM-9531] - CVE-2021-0341 okhttp dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,12 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 
-    ext.kotlin_version = "1.7.20"
+
+    ext {
+        kotlin_version = "1.7.20"
+        okhttp3_version = "4.11.0"
+    }
+
 
     repositories {
         google()
@@ -16,6 +21,15 @@ buildscript {
 }
 
 allprojects {
+
+    configurations.all {
+        resolutionStrategy {
+            force "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+            force "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"
+            force "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+            force "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
+        }
+    }
 
     repositories {
 

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -8,47 +8,37 @@ buildscript {
 }
 
 plugins {
-
     id 'com.android.library'
 }
-
 
 subprojects {
     apply plugin: 'org.owasp.dependencycheck'
 }
 
 android {
-
     compileSdkVersion 31
-
     defaultConfig {
-
         minSdkVersion 19
         targetSdkVersion 31
         versionCode 12
         versionName "1.1.4"
-
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     buildTypes {
-
         release {
-
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
 
     compileOptions {
-
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
     afterEvaluate {
-
         generateReleaseBuildConfig.enabled = false
         generateDebugBuildConfig.enabled = false
     }
@@ -61,8 +51,8 @@ dependencies {
     implementation 'androidx.annotation:annotation:1.3.0'
     implementation 'org.apache.commons:commons-lang3:3.11'
 
-    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.9.0'
+    implementation "com.squareup.okhttp3:okhttp:$okhttp3_version"
+    implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3_version"
 
     implementation 'io.swagger:swagger-annotations:1.5.24'
 
@@ -72,8 +62,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.10.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
-    testImplementation 'com.squareup.okhttp3:okhttp-tls:4.9.0'
+    testImplementation "com.squareup.okhttp3:mockwebserver:$okhttp3_version"
+    testImplementation "com.squareup.okhttp3:okhttp-tls:$okhttp3_version"
     testImplementation 'org.json:json:20180813'
     testImplementation 'com.google.guava:guava:31.1-android'
 


### PR DESCRIPTION
[FFM-9531] - CVE-2021-0341 okhttp dependency to 4.11.0

What
Bump okhttp version from 4.9.0 to 4.11.0

Why
Removes several CVEs including kotlin-stdlib 1.4.10 and okio 2.8.0

Testing
Manual

[FFM-9531]: https://harness.atlassian.net/browse/FFM-9531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ