### PR TITLE
[FFM-9530] - CVE-2022-25647 update gson dependency

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -56,7 +56,8 @@ dependencies {
 
     implementation 'io.swagger:swagger-annotations:1.5.24'
 
-    implementation 'io.gsonfire:gson-fire:1.8.4'
+    implementation 'com.google.code.gson:gson:2.10.1'
+
     implementation 'org.threeten:threetenbp:1.4.3'
     implementation 'com.orhanobut:hawk:2.0.1'
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/core/client/JSON.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/core/client/JSON.java
@@ -35,7 +35,6 @@ import java.text.ParsePosition;
 import java.util.Date;
 import java.util.Map;
 
-import io.gsonfire.GsonFireBuilder;
 import okio.ByteString;
 
 public class JSON {
@@ -46,13 +45,6 @@ public class JSON {
     private OffsetDateTimeTypeAdapter offsetDateTimeTypeAdapter = new OffsetDateTimeTypeAdapter();
     private LocalDateTypeAdapter localDateTypeAdapter = new LocalDateTypeAdapter();
     private ByteArrayAdapter byteArrayAdapter = new ByteArrayAdapter();
-
-    public static GsonBuilder createGson() {
-        GsonFireBuilder fireBuilder = new GsonFireBuilder()
-        ;
-        GsonBuilder builder = fireBuilder.createGsonBuilder();
-        return builder;
-    }
 
     private static String getDiscriminatorValue(JsonElement readElement, String discriminatorField) {
         JsonElement element = readElement.getAsJsonObject().get(discriminatorField);
@@ -78,7 +70,7 @@ public class JSON {
     }
 
     public JSON() {
-        gson = createGson()
+        gson = new GsonBuilder()
             .registerTypeAdapter(Date.class, dateTypeAdapter)
             .registerTypeAdapter(java.sql.Date.class, sqlDateTypeAdapter)
             .registerTypeAdapter(OffsetDateTime.class, offsetDateTimeTypeAdapter)


### PR DESCRIPTION
[FFM-9530] - CVE-2022-25647 update gson dependency

What
Update gson dependency to latest. Also remove gson-fire as it hasn't been seen a release in several years and we don't seem to use it.

Why
gson-fire is bringing in an older version of gson which has a CVE against it.

Testing
Manual

[FFM-9530]: https://harness.atlassian.net/browse/FFM-9530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ