### PR TITLE
[FFM-9572] - Bump minSdk to 21 and targetSdk to 33

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -16,10 +16,10 @@ subprojects {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 12
         versionName "1.1.4"
         consumerProguardFiles "consumer-rules.pro"

--- a/examples/tlsexample/build.gradle
+++ b/examples/tlsexample/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace 'io.harness.cfsdk.tlsexample'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "io.harness.cfsdk.tlsexample"
-        minSdkVersion 19
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
 


### PR DESCRIPTION
[FFM-9572] - Bump minSdk to 21 and targetSdk to 33

What
Update minSdk and targetSdk to minimum versions required by Google

Why
As of August 2023 Google is discontinuing updates for API levels 19/20 See https://android-developers.googleblog.com/2023/07/google-play-services-discontinuing-updates-for-kitkat.html

Also bump targetSdk to min 33 as per https://developer.android.com/google/play/requirements/target-sdk

Testing
Manual