### PR TITLE
[FFM-9598] -  jsonVariation always returns default value

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -49,10 +49,7 @@ apply from: "${rootProject.projectDir}/cfsdk/publish-mavencentral.gradle"
 dependencies {
 
     implementation 'org.slf4j:slf4j-api:2.0.9'
-
     implementation 'androidx.annotation:annotation:1.3.0'
-    implementation 'org.apache.commons:commons-lang3:3.11'
-
     implementation "com.squareup.okhttp3:okhttp:$okhttp3_version"
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3_version"
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -6,7 +6,6 @@ import android.content.Context;
 
 import androidx.annotation.Nullable;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -863,9 +862,7 @@ public class CfClient implements Destroyable {
 
                     return e.getValue();
                 }
-                String eval = StringEscapeUtils.unescapeJava(e.getValue().toString());
-                eval = eval.substring(1, eval.length() - 1);
-                return new JSONObject(eval);
+                return new JSONObject(e.getValue().toString());
             }
         } catch (JSONException e) {
 

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -33,6 +33,8 @@ import androidx.annotation.NonNull;
 
 import com.google.common.util.concurrent.AtomicLongMap;
 
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -555,6 +557,34 @@ public class CfClientTest {
             }
         }
 
+    }
+
+    @Test
+    public void variationMethodsShouldNotReturnDefaults() throws JSONException {
+
+        CfClient client = new CfClient() {
+            @Override
+            <T> Evaluation getEvaluationById( String evaluationId, Target target, T defaultValue ) {
+                switch (evaluationId) {
+                    case "boolflag": return new Evaluation().flag("bool1").kind("boolean").value("true").identifier("b1");
+                    case "strflag": return new Evaluation().flag("string1").kind("string").value("str").identifier("s1");
+                    case "numflag": return new Evaluation().flag("number1").kind("number").value("123").identifier("n1");
+                    case "jsonflag": return new Evaluation().flag("json1").kind("json").value("{'flag':'on'}").identifier("j1");
+                    default: throw new RuntimeException("unknown eval id " + evaluationId);
+                }
+            }
+        };
+
+        boolean boolResult = client.boolVariation("boolflag", false);
+        String strResult = client.stringVariation("strflag", "");
+        double numResult = client.numberVariation("numflag", 0);
+        JSONObject jsonResult = client.jsonVariation("jsonflag", new JSONObject("{}"));
+
+        assertTrue(boolResult);
+        assertEquals("str", strResult);
+        assertEquals(123, numResult, .0);
+        assertNotNull("default (or wrong) json returned", jsonResult.get("flag"));
+        assertEquals("on", jsonResult.get("flag"));
     }
 
 }


### PR DESCRIPTION
What
Fix input to JSONObject and remove unneeded Apache dependency

Why
There’s a bug in how we parse the JSON returned to jsonVariation. Before passing to JSONObject we strip off the surrounding braces which causes an exception to be thrown

E/CfClient: Value flag of type java.lang.String cannot be converted to JSONObject
    org.json.JSONException: Value flag of type java.lang.String cannot be converted to JSONObject
        at org.json.JSON.typeMismatch(JSON.java:111)
        at org.json.JSONObject.<init>(JSONObject.java:163)
        at org.json.JSONObject.<init>(JSONObject.java:176)
        at io.harness.cfsdk.CfClient.jsonVariation(CfClient.java:872)
        at com.example.android_sdk_test.MainActivity.lambda$onCreate$2(MainActivity.java:146)
        at com.example.android_sdk_test.MainActivity.$r8$lambda$yX3gDMwxpCIvBmOil3jvG5PQc7c(Unknown Source:0)
        at com.example.android_sdk_test.MainActivity$$ExternalSyntheticLambda2.run(Unknown Source:2)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:457)
        at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:307)
        at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:302)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1162)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:636)
        at java.lang.Thread.run(Thread.java:764)

Testing
Manual + new unit test