### PR TITLE
[FFM-9347] - Avoid posting metrics if total evaluation count is 0

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsPublisherService.java
@@ -89,10 +89,14 @@ public class AnalyticsPublisherService {
                     log.trace("metrics payload: {}", metrics);
 
                 final long evalSum = sumOfValuesInMap(freqMap);
-                metricsApi.postMetrics(authInfo.getEnvironment(), metrics);
-                metricsSent.addAndGet(evalSum);
 
-                log.debug("Successfully sent analytics data to the server");
+                if (evalSum > 0) {
+                    metricsApi.postMetrics(authInfo.getEnvironment(), metrics);
+                    metricsSent.addAndGet(evalSum);
+                    log.debug("Successfully sent analytics data to the server");
+                } else {
+                    log.debug("Sum of metric evaluations is 0 - metrics post skipped");
+                }
 
             } else {
                 log.debug("No analytics data to send the server");


### PR DESCRIPTION
[FFM-9347] - Avoid posting metrics if total evaluation count is 0

What
If total sum of evaluations is equal to zero then skip sending the metrics payload this iteration.

Why
We're seeing payloads with 0 counts on the backend. We want to avoid wasting bandwidth.

Testing
New unit test

[FFM-9347]: https://harness.atlassian.net/browse/FFM-9347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ