### PR TITLE
[FFM-8526] - Add retry interceptor to authentication

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
@@ -30,6 +30,7 @@ public class NewRetryInterceptor implements Interceptor {
   public Response intercept(@NotNull Chain chain) throws IOException {
     int tryCount = 1;
     boolean successful;
+    boolean limitReached = false;
     Response response = null;
     String msg = "";
     do {
@@ -58,7 +59,7 @@ public class NewRetryInterceptor implements Interceptor {
         }
       }
       if (!successful) {
-        final boolean limitReached = tryCount > maxTryCount;
+        limitReached = tryCount >= maxTryCount;
         log.warn(
             "Request attempt {} to {} was not successful, [{}]{}",
             tryCount,
@@ -72,7 +73,8 @@ public class NewRetryInterceptor implements Interceptor {
           sleep(retryBackoffDelay * tryCount);
         }
       }
-    } while (!successful && tryCount++ <= maxTryCount);
+      tryCount++;
+    } while (!successful && !limitReached);
 
     return response;
   }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
@@ -3,6 +3,7 @@ package io.harness.cfsdk.cloud.sse;
 import static io.harness.cfsdk.cloud.sse.StatusEvent.makeSseEndEvent;
 import static io.harness.cfsdk.cloud.sse.StatusEvent.makeSseResumeEvent;
 import static io.harness.cfsdk.cloud.sse.StatusEvent.makeSseStartEvent;
+import static java.util.concurrent.ThreadLocalRandom.current;
 
 import androidx.annotation.NonNull;
 
@@ -35,7 +36,6 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 public class EventSource implements Callback, AutoCloseable {
 
   private static final Logger log = LoggerFactory.getLogger(EventSource.class);
@@ -55,7 +55,7 @@ public class EventSource implements Callback, AutoCloseable {
       Map<String, String> headers,
       @NonNull EventsListener eventListener,
       long sseReadTimeoutMins) {
-    this(url, headers, eventListener, sseReadTimeoutMins, 2_000, null);
+    this(url, headers, eventListener, sseReadTimeoutMins, current().nextInt(2000, 5000), null);
   }
 
   public EventSource(


### PR DESCRIPTION
[FFM-8526] - Add retry interceptor to authentication

What
Enable the retry interceptor so authentication requests can be retried several times (with a random interval)

Why
Add more network resilience so we don't immediately bail out when a transient network error happens.

Testing
Unit tests + manual

[FFM-8526]: https://harness.atlassian.net/browse/FFM-8526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ