### PR TITLE
[FFM-9559] - Add waitForInitialization()

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -459,6 +459,7 @@ public class CfClient implements Closeable {
      */
     public boolean waitForInitialization(long timeoutMs) {
         try {
+            SdkCodes.infoSdkWaitingForInit();
             if (initLatch.await(timeoutMs, TimeUnit.MILLISECONDS) && (authInfo != null)) {
                 return true;
             }
@@ -476,6 +477,7 @@ public class CfClient implements Closeable {
      * @since 1.2.0
      */
     public void waitForInitialization() throws InterruptedException {
+        SdkCodes.infoSdkWaitingForInit();
         initLatch.await();
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -450,7 +450,7 @@ public class CfClient implements Closeable {
 
 
     /**
-     * Wait for the SDK to authenticate and populate it cache.
+     * Wait for the SDK to authenticate and populate its cache.
      * @param timeoutMs Timeout in milliseconds to wait for SDK to initialize
      * @return Returns true if successfully initialized else false if timed out or something went
      * wrong. If false is returned, your code may proceed to use xVariation functions however

--- a/cfsdk/src/main/java/io/harness/cfsdk/common/SdkCodes.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/common/SdkCodes.java
@@ -31,6 +31,11 @@ public class SdkCodes {
       log.info(sdkErrMsg(1000));
   }
 
+  public static void infoSdkWaitingForInit() {
+    if (log.isInfoEnabled())
+      log.info(sdkErrMsg(1003));
+  }
+
   public static void infoSdkAuthOk() {
     if (log.isInfoEnabled())
       log.info(sdkErrMsg(2000));
@@ -97,6 +102,7 @@ public class SdkCodes {
     put(1000, "The SDK has successfully initialized");
     put(1001, "The SDK has failed to initialize due to the following authentication error:");
     put(1002, "The SDK has failed to initialize due to a missing or empty API key");
+    put(1003, "The SDK is waiting for initialization to complete");
 
     put(2000, "Authenticated ok");
     put(2001, "Authentication failed with a non-recoverable error - defaults will be served");

--- a/cfsdk/src/test/java/io/harness/cfsdk/common/SdkCodesTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/common/SdkCodesTest.java
@@ -16,6 +16,7 @@ public class SdkCodesTest {
             errorMissingSdkKey();
             infoPollStarted(123);
             infoSdkInitOk();
+            infoSdkWaitingForInit();
             infoSdkAuthOk();
             infoPollingStopped();
             infoStreamConnected();


### PR DESCRIPTION
[FFM-9559] - Add waitForInitialization()

What
Adds waitForInitialization() and waitForInitialization(timeoutMs)

Why
We want to be consistent with other SDKs and give threads the ability to wait for SDKs to fully authenticate and populate their cache

Testing
Manual

[FFM-9559]: https://harness.atlassian.net/browse/FFM-9559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ