### PR TITLE
[FFM-8529] - Fix SSE re-connect from previous commit

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
@@ -210,10 +210,6 @@ public class EventSource implements Callback, AutoCloseable {
       SdkCodes.warnStreamDisconnected(ex.getMessage());
       log.warn("SSE stream aborted", ex);
       eventListener.onEventReceived(makeSseEndEvent());
-      if (ex instanceof SSEStreamException) {
-        throw ex;
-      }
-      throw new SSEStreamException(ex.getMessage(), ex);
     }
   }
 


### PR DESCRIPTION
[FFM-8529] - Fix SSE re-connect from previous commit

What
Previous commit threw an exception killing the main activity thread, instead we only want to send an SSE_END event to get the SDK to run reschedule()

Why
Java SDK has different exception handling to Android

Testing
Manual

[FFM-8529]: https://harness.atlassian.net/browse/FFM-8529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ