### PR TITLE
FFM-9941 Fix incorrect event orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ buildscript {
 
 In app module's [build.gradle](https://github.com/harness/ff-android-client-sdk/blob/main/examples/GettingStarted/app/build.gradle#L41) file add dependency for Harness's SDK
 
-`implementation 'io.harness:ff-android-client-sdk:1.2.0'`
+`implementation 'io.harness:ff-android-client-sdk:1.2.1'`
 
 
 ### Code Sample

--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -37,7 +37,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.2.0"
+    PUBLISH_VERSION = "1.2.1"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.2.0";
+    public static final String ANDROID_SDK_VERSION = "1.2.1";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -578,11 +578,9 @@ public class CfClient implements Closeable {
                 break;
 
             case EVALUATION_RELOAD:
-                // TODO - add a try around this payload - possibly triggered by other things too
-                List<Evaluation> reloadEvaluations = statusEvent.extractEvaluationListPayload();
-
                 // if evaluations are present in sse event save it directly, else fetch from server
-                if(areEvaluationsValid(reloadEvaluations)) {
+                if(areEvaluationsValid(statusEvent.extractEvaluationListPayload())) {
+                    List<Evaluation> reloadEvaluations = statusEvent.extractEvaluationListPayload();
                     for (int i = 0; i < reloadEvaluations.size(); i++) {
                         featureRepository.save(authInfo.getEnvironmentIdentifier(), target.getIdentifier(), reloadEvaluations.get(i));
                         notifyListeners(reloadEvaluations.get(i));
@@ -602,7 +600,7 @@ public class CfClient implements Closeable {
                     );
 
                     for (int i = 0; i < fetchedEvaluations.size(); i++) {
-                        notifyListeners(reloadEvaluations.get(i));
+                        notifyListeners(fetchedEvaluations.get(i));
                     }
 
                     StatusEvent evalReloadEvent = new StatusEvent(StatusEvent.EVENT_TYPE.EVALUATION_RELOAD, fetchedEvaluations);

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -44,7 +44,7 @@ android {
 dependencies {
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
-    implementation 'io.harness:ff-android-client-sdk:1.2.0'
+    implementation 'io.harness:ff-android-client-sdk:1.2.1'
 
     implementation 'com.github.tony19:logback-android:3.0.0'
     implementation 'androidx.core:core-ktx:1.7.0'

--- a/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "harnessappdarkmode" }
+    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "harnessappdemodarkmode" }
 
     // The SDK API Key to use for authentication.  Configure it when installing the app by setting FF_API_KEY
     // e.g. FF_API_KEY='my key' ./gradlew installDebug
@@ -31,7 +31,7 @@ class MainActivity : AppCompatActivity() {
 
 
         if (flagName.equals("null")) {
-            flagName = "harnessappdarkmode"
+            flagName = "harnessappdemodarkmode"
         }
 
         // Create Default Configuration for the SDK.  We can use this to disable streaming,

--- a/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -18,7 +18,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "boolflag" }
+    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "harnessappdarkmode" }
 
     // The SDK API Key to use for authentication.  Configure it when installing the app by setting FF_API_KEY
     // e.g. FF_API_KEY='my key' ./gradlew installDebug
@@ -31,7 +31,7 @@ class MainActivity : AppCompatActivity() {
 
 
         if (flagName.equals("null")) {
-            flagName = "boolflag"
+            flagName = "harnessappdarkmode"
         }
 
         // Create Default Configuration for the SDK.  We can use this to disable streaming,

--- a/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -1,6 +1,7 @@
 package io.harness.cfsdk.gettingstarted
 
 import android.os.Bundle
+import android.util.Log
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import ch.qos.logback.classic.android.BasicLogcatConfigurator
@@ -17,7 +18,7 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "harnessappdemodarkmode" }
+    private var flagName: String = BuildConfig.FF_FLAG_NAME.ifEmpty { "boolflag" }
 
     // The SDK API Key to use for authentication.  Configure it when installing the app by setting FF_API_KEY
     // e.g. FF_API_KEY='my key' ./gradlew installDebug
@@ -30,7 +31,7 @@ class MainActivity : AppCompatActivity() {
 
 
         if (flagName.equals("null")) {
-            flagName = "harnessappdemodarkmode"
+            flagName = "boolflag"
         }
 
         // Create Default Configuration for the SDK.  We can use this to disable streaming,

--- a/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/app/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -13,7 +13,6 @@ class MainActivity : AppCompatActivity() {
 
     companion object {
         init {
-
             BasicLogcatConfigurator.configureDefaultContext() // enable SDK logging to logcat
         }
     }


### PR DESCRIPTION
# What

When a flag is toggled while the device is offline, when the device comes back online and gets notified of the change, it can take a few attempts for it to pull the latest evaluation back from the client service. The problem is the method relied on mutating the original callback `statusEvent` parameter, and then it emitted it at the end with its final mutated state. However, because the fetch call from the client service is happens concurrently, the `statusEvent` variable might not get mutated in time, and we’d emit the original event which comes through as a List<Evaluation> . 

This PR tidied up the `eventsListener` method to

- No longer mutate the callback `statusEvent` 
- Create a new `StatusEvent` for each event type, and emit it directly there. 

It also:

- Does not mutate evaluation lists used between `EVALUATED_CHANGE` and `EVALUATION_RELOADED` but uses separate lists. 
- Notifies evaluation listeners for `SSE_REMOVE` 
- Notifies evaluation listeners for `SSE_RELOAD` 

# Testing
Manual 
- Turned off network on emulator, toggled flag, then reneabled network. The correct evaluation now gets sent to the app.