### PR TITLE
FFM-10297 Fix handling of default variations

### DIFF
--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -37,7 +37,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.2.1"
+    PUBLISH_VERSION = "1.2.2"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.2.1";
+    public static final String ANDROID_SDK_VERSION = "1.2.2";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -313,6 +313,7 @@ public class CfClient implements Closeable {
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
         }
 
+        pushToMetrics(evaluationId, evaluation);
         return "true".equals(value);
     }
 
@@ -333,6 +334,7 @@ public class CfClient implements Closeable {
             return defaultValue;
         }
 
+        pushToMetrics(evaluationId, evaluation);
         return evaluation.getValue();
     }
 
@@ -356,7 +358,10 @@ public class CfClient implements Closeable {
         }
 
         try {
-            return Double.parseDouble(value);
+            double parsedVal = Double.parseDouble(value);
+            pushToMetrics(evaluationId, evaluation);
+            return parsedVal;
+
         } catch (NumberFormatException e) {
             log.warn("Error parsing evaluation value as double: '{}' returning default variation ", e.getMessage(), e);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
@@ -381,7 +386,9 @@ public class CfClient implements Closeable {
 
         try {
             // Attempt to parse the evaluation value as a JSONObject
-            return new JSONObject(evaluation.getValue());
+            JSONObject parsedVal = new JSONObject(evaluation.getValue());
+            pushToMetrics(evaluationId, evaluation);
+            return parsedVal;
         } catch (JSONException e) {
             log.error("Error parsing evaluation value as JSONObject: " + e.getMessage(), e);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, defaultValue.toString());

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -305,13 +305,13 @@ public class CfClient implements Closeable {
             return defaultValue;
         }
 
-        final Object value = evaluation.getValue();
+        final String value = evaluation.getValue();
         if (value == null) {
             log.warn("Evaluation was found for '{}', but the value was null, " +
                     "returning default variation", evaluationId);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
         }
-        
+
         return "true".equals(value);
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -337,31 +337,30 @@ public class CfClient implements Closeable {
 
     public double numberVariation(String evaluationId, double defaultValue) {
 
-        final Evaluation evaluation = getEvaluationById(
+        final Evaluation evaluation = getEvaluationById(evaluationId, target);
 
-                evaluationId,
-                target,
-                defaultValue
-        );
-
-        final Object value = evaluation.getValue();
-        if (value instanceof Number) {
-
-            return ((Number) value).doubleValue();
+        if (evaluation == null) {
+            log.warn("Evaluation is null, returning default value");
+            SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
         }
-        if (value instanceof String) {
 
-            final String strValue = (String) value;
-            try {
+        String value = evaluation.getValue();
 
-                return Double.parseDouble(strValue);
-            } catch (NumberFormatException e) {
-
-                log.error(e.getMessage(), e);
-            }
+        if (value == null) {
+            log.warn("Evaluation was found for '{}', but the value was null, " +
+                    "returning default variation", evaluationId);
+            SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
         }
-        SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
-        return defaultValue;
+
+        try {
+            return Double.parseDouble(value);
+        } catch (NumberFormatException e) {
+            log.error("Error parsing evaluation value as double: " + e.getMessage(), e);
+            SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
+        }
     }
 
     public JSONObject jsonVariation(String evaluationId, JSONObject defaultValue) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -386,8 +386,19 @@ public class CfClient implements Closeable {
         }
 
         try {
+            String originalValue = evaluation.getValue();
+
+            // Remove outer quotes if they exist. Having to unescape by hand as we don't want
+            // to use large libraries like commons/gson
+            if (originalValue.startsWith("\"") && originalValue.endsWith("\"") && originalValue.length() > 1) {
+                originalValue = originalValue.substring(1, originalValue.length() - 1);
+            }
+
+            // Replace escaped inner quotes
+            originalValue = originalValue.replace("\\\"", "\"");
+
+            JSONObject parsedVal = new JSONObject(originalValue);
             // Attempt to parse the evaluation value as a JSONObject
-            JSONObject parsedVal = new JSONObject(evaluation.getValue());
             pushToMetrics(evaluationId, evaluation);
             return parsedVal;
         } catch (JSONException e) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -317,7 +317,22 @@ public class CfClient implements Closeable {
 
     public String stringVariation(String evaluationId, String defaultValue) {
 
-        return getEvaluationById(evaluationId, target, defaultValue).getValue();
+        Evaluation evaluation = getEvaluationById(evaluationId, target);
+
+        if (evaluation == null) {
+            log.warn("Using default value for stringVariation as evaluation is null or value is null");
+            SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
+        }
+
+        if (evaluation.getValue() == null) {
+            log.warn("Evaluation was found for '{}', but the value was null, " +
+                    "returning default variation", evaluationId);
+            SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
+        }
+
+        return evaluation.getValue();
     }
 
     public double numberVariation(String evaluationId, double defaultValue) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -301,6 +301,7 @@ public class CfClient implements Closeable {
         final Evaluation evaluation = getEvaluationById(evaluationId, target);
 
         if (evaluation == null) {
+            log.warn("Evaluation for {} is null, returning default value", evaluationId);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
             return defaultValue;
         }
@@ -320,7 +321,7 @@ public class CfClient implements Closeable {
         Evaluation evaluation = getEvaluationById(evaluationId, target);
 
         if (evaluation == null) {
-            log.warn("Using default value for stringVariation as evaluation is null or value is null");
+            log.warn("Evaluation for {} is null, returning default value", evaluationId);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
             return defaultValue;
         }
@@ -340,7 +341,7 @@ public class CfClient implements Closeable {
         final Evaluation evaluation = getEvaluationById(evaluationId, target);
 
         if (evaluation == null) {
-            log.warn("Evaluation is null, returning default value");
+            log.warn("Evaluation for {} is null, returning default value", evaluationId);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
             return defaultValue;
         }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -311,6 +311,7 @@ public class CfClient implements Closeable {
             log.warn("Evaluation was found for '{}', but the value was null, " +
                     "returning default variation", evaluationId);
             SdkCodes.warnDefaultVariationServed(evaluationId, target, String.valueOf(defaultValue));
+            return defaultValue;
         }
 
         pushToMetrics(evaluationId, evaluation);

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -896,11 +896,15 @@ public class CfClient implements Closeable {
     /* ---------- Package private ---------- */
 
     /**
-     * Retrieves single {@link Evaluation instance} based on provided id. If no such evaluation is found,
-     * returns one with provided default value.
+     * Retrieves a single {@link Evaluation} instance based on the provided id. If the SDK is not ready or
+     * if no evaluation is found for the given id, the method returns null.
      *
-     * @param evaluationId Identifier of target evaluation
-     * @return Evaluation for a given id
+     * This method is responsible only for fetching the evaluation and does not handle default values.
+     * The calling methods should handle the case when null is returned.
+     *
+     * @param evaluationId Identifier of the target evaluation
+     * @param target       The target for which the evaluation is to be fetched
+     * @return Evaluation for the given id if found, otherwise null
      */
     <T> Evaluation getEvaluationById(
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -921,7 +921,7 @@ public class CfClient implements Closeable {
      * The calling methods should handle the case when null is returned.
      *
      * @param evaluationId Identifier of the target evaluation
-     * @param target       The target for which the evaluation is to be fetched
+     * @param target The target used for the evaluation
      * @return Evaluation for the given id if found, otherwise null
      */
     <T> Evaluation getEvaluationById(


### PR DESCRIPTION
# What
If a default variation was returned, for example if a nonexistent flag was evaluated against, then the SDK would crash on an unchecked `ClassCastException` when trying to cast the user supplied default value to string. The method responsible was `getEvaluationById` and the default value could be `bool`, `double`, `string`, or `JSONObject` so this was not a valid approach.

# Fixes
- `getEvaluationID` now returns `null` in cases where it can't return an `Evaluation` and responsibility is delegated to the variation methods to check for null and safely return the defaults. No casting is required here.
- `jsonVariation` now actually returns the default variation, instead of a json object with flagID + null as the KV.
-  No longer post metrics if an evaluation fails

# Quality improvements
- Refactored `getEvaluatoinById` and variation methods to aid maintainability and readability. 
- variation methods are now responsible for posting metrics

# Testing
- Manual: 
    -  All variation methods now no longer cause `ClassCastException` if the default variation is returned. 
    - SDK evaluates and post metrics as normal
- Updated unit tests