### PR TITLE
FFM-10359 Fix uncaught exception if initialization fails

### DIFF
--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -37,7 +37,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.2.2"
+    PUBLISH_VERSION = "1.2.3"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.2.2";
+    public static final String ANDROID_SDK_VERSION = "1.2.3";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -801,7 +801,6 @@ public class CfClient implements Closeable {
 
             setTargetDefaults(target);
 
-            // TODO wrap with Future due to uncaught exception below
             executor.execute(() -> runInitThreadWrapEx(apiKey, cloudCache, authCallback));
 
         } catch (Exception e) {
@@ -875,7 +874,13 @@ public class CfClient implements Closeable {
         try {
             runInitThread(apiKey, cloudCache, authCallback);
         } catch (ApiException e) {
-            throw new RejectedExecutionException(e);
+            log.error("Error when initializing: " + e.getMessage());
+
+            if (authCallback != null) {
+                AuthResult authResult = new AuthResult(false, e);
+                authCallback.authorizationSuccess(authInfo, authResult);
+                close();
+            }
         }
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -811,7 +811,6 @@ public class CfClient implements Closeable {
                 final AuthResult result = new AuthResult(false, cause);
                 authCallback.authorizationSuccess(authInfo, result);
             }
-
             close();
         }
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -801,6 +801,7 @@ public class CfClient implements Closeable {
 
             setTargetDefaults(target);
 
+            // TODO wrap with Future due to uncaught exception below
             executor.execute(() -> runInitThreadWrapEx(apiKey, cloudCache, authCallback));
 
         } catch (Exception e) {

--- a/examples/GettingStarted/app/build.gradle
+++ b/examples/GettingStarted/app/build.gradle
@@ -44,7 +44,7 @@ android {
 dependencies {
 
     coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.0.3")
-    implementation 'io.harness:ff-android-client-sdk:1.2.1'
+    implementation 'io.harness:ff-android-client-sdk:1.2.3'
 
     implementation 'com.github.tony19:logback-android:3.0.0'
     implementation 'androidx.core:core-ktx:1.7.0'


### PR DESCRIPTION
# What
If initialization failed, an exception was thrown from within the thread pool which could not be caught by the try-catch that was used outside of it it. This caused an uncaught exception to crash the thread and user application. 
This change returns an auth result, instead of throwing an exception. This was used over a `Future` which is a blocking call.

# Testing
Manual, sample application.