### PR TITLE
[FFM-10477] - Fix null pointer when calling initialize()

### DIFF
--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -37,7 +37,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.2.3"
+    PUBLISH_VERSION = "1.2.4"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.2.3";
+    public static final String ANDROID_SDK_VERSION = "1.2.4";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -744,6 +744,8 @@ public class CfClient implements Closeable {
 
     protected void registerNetworkConnectedListener(Context context) {
 
+        // Note that if the network goes down all API requests will throw 'Unable to resolve host "config.ff.harness.io"' (Android 13/API 33)
+
         if (networkInfoProvider != null) {
             networkInfoProvider.unregisterAll();
         } else {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -152,7 +152,7 @@ public class CfClient implements Closeable {
 
         setupNetworkInfo(context);
 
-        doInitialize(apiKey, configuration, target, cloudCache, authCallback);
+        initializeInternal(apiKey, configuration, target, cloudCache, authCallback);
     }
 
     /**
@@ -698,7 +698,7 @@ public class CfClient implements Closeable {
         log.info("SDK will restart in {}ms", delayMs);
         TimeUnit.MILLISECONDS.sleep(delayMs);
 
-        if (!ready.get() && cloud.initialize()) {
+        if (!ready.get() && cloud != null && cloud.initialize()) {
             ready.set(true);
             this.authInfo = cloud.getAuthInfo();
 
@@ -779,7 +779,7 @@ public class CfClient implements Closeable {
         }};
     }
 
-    protected void doInitialize(
+    protected void initializeInternal(
             final String apiKey,
             final CfConfiguration configuration,
             final Target target,
@@ -873,7 +873,7 @@ public class CfClient implements Closeable {
         try {
             runInitThread(apiKey, cloudCache, authCallback);
         } catch (ApiException e) {
-            log.error("Error when initializing: " + e.getMessage());
+            log.error("Error when initializing: " + e.getMessage(), e);
 
             if (authCallback != null) {
                 AuthResult authResult = new AuthResult(false, e);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/sse/EventSource.java
@@ -226,8 +226,6 @@ public class EventSource implements Callback, AutoCloseable {
   private void sseMessage(String message) {
 
     try {
-      SdkCodes.infoStreamEventReceived(message);
-
       final JSONObject jsonObject = new JSONObject(message);
       final String domain = jsonObject.getString("domain");
       final String eventType = jsonObject.getString("event");


### PR DESCRIPTION
**What**
This is a minimum fix to get rid of a null pointer exception that can happen. First approach was to make `cloud` final to guarantee it can never be null however `getInstance()` prevents us from doing that since it controls the instance creation. Second approach was to move `this.cloud = cloudFactory.cloud()` before init thread creation however this results in a `NetworkOnMainThreadException`.

For now adding a simple null check but the proper fix is to refactor the code into worker threads and avoid assigning class members from different threads.

Plus:
- Fix a problem where SDK would not reconnect when started with no network
- Remove duplicate SSE event log

**Why**
See seeing a race condition between the init and reschedule when an SDK is started with no network

**Testing**
Manual