### PR TITLE
[FFM-10477] - Avoid throwing RejectedExecutionException

### DIFF
--- a/cfsdk/publish-mavencentral.gradle
+++ b/cfsdk/publish-mavencentral.gradle
@@ -37,7 +37,7 @@ artifacts {
 ext {
     PUBLISH_GROUP_ID = "io.harness"
     PUBLISH_ARTIFACT_ID = "ff-android-client-sdk"
-    PUBLISH_VERSION = "1.2.4"
+    PUBLISH_VERSION = "1.2.5"
 }
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "1.2.4";
+    public static final String ANDROID_SDK_VERSION = "1.2.5";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -692,8 +692,6 @@ public class CfClient implements Closeable {
             if (networkInfoProvider.isNetworkAvailable()) {
                 evaluationPolling.start(this::reschedule);
             }
-
-            throw new RejectedExecutionException(ex);
         }
     }
 

--- a/examples/tlsexample/src/main/java/io/harness/cfsdk/tlsexample/MainActivity.kt
+++ b/examples/tlsexample/src/main/java/io/harness/cfsdk/tlsexample/MainActivity.kt
@@ -136,7 +136,7 @@ class MainActivity : AppCompatActivity() {
         super.onDestroy()
         timer.cancel()
         timer.purge()
-        client.destroy()
+        client.close()
     }
 
     private fun setupWatchTimer() {


### PR DESCRIPTION
**What**
Don't throw `RejectedExecutionException` inside `runRescheduleThreadWrapEx()`

**Why**
We're causing a fatal exception to be caught by the `Executor` service for exceptions that are not fatal in nature (e.g. `ApiException`). Instead we should call `reschedule()` to allow the SDK time to restart

**Testing**
Manual