### PR TITLE
[FFM-10745] - Add support for Retry-After header

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.0.0";
+    public static final String ANDROID_SDK_VERSION = "2.0.1";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
@@ -63,7 +63,7 @@ public class NewRetryInterceptor implements Interceptor {
 
       } catch (Exception ex) {
         log.trace("Error while attempting to make request", ex);
-        msg = ex.getMessage();
+        msg = ex.getClass().getSimpleName() + ": " + ex.getMessage();
         response = makeErrorResp(chain, msg);
         successful = false;
         if (!shouldRetryException(ex)) {
@@ -147,7 +147,7 @@ public class NewRetryInterceptor implements Interceptor {
 
   private Response makeErrorResp(Chain chain, String msg) {
     return new Response.Builder()
-        .code(404) /* dummy response: real reason is in the message */
+        .code(400) /* dummy response: real reason is in the message */
         .request(chain.request())
         .protocol(Protocol.HTTP_2)
         .message(msg)

--- a/cfsdk/src/test/java/io/harness/cfsdk/cloud/network/NewRetryInterceptorTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/cloud/network/NewRetryInterceptorTest.java
@@ -1,0 +1,28 @@
+package io.harness.cfsdk.cloud.network;
+
+import static junit.framework.TestCase.assertEquals;
+
+import org.junit.Test;
+
+import okhttp3.Protocol;
+import okhttp3.Request;
+import okhttp3.Response;
+
+public class NewRetryInterceptorTest {
+
+    @Test
+    public void shouldParseRetryHeader() {
+        final NewRetryInterceptor interceptor = new NewRetryInterceptor(0);
+        final Request dummyReq = new Request.Builder().url("http://test.com").build();
+        assertEquals(0, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(100).addHeader("Retry-After", "1").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(0, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(200).addHeader("Retry-After", "1").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(0, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(429).request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(0, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(503).request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(111, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(301).addHeader("Retry-After", "111").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(321, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(429).addHeader("Retry-After", "321").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(123, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(503).addHeader("Retry-After", "123").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(3600, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(503).addHeader("Retry-After", "999999999").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(3600, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(503).addHeader("Retry-After", "Sat, 1 Jan 2050 00:00:00 GMT").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+        assertEquals(0, interceptor.getRetryAfterHeaderInSeconds( new Response.Builder().code(503).addHeader("Retry-After", "Mon, 1 Jan 1990 00:00:00 GMT").request(dummyReq).protocol(Protocol.HTTP_2).message("").build()));
+    }
+}

--- a/examples/tlsexample/src/main/res/xml/network_security_config.xml
+++ b/examples/tlsexample/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.0.0')
+            version('sdk', '2.0.1')
         }
     }
 }


### PR DESCRIPTION
**What**
If Retry-After header is detected, use that first when retrying a failed API connection

**Why**
Allow backend to control when SDKs retry

**Testing**
Manual + unit testing