### PR TITLE
FFM-8138 Fix V2 `initialize` not returning 

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -105,7 +105,7 @@ public class CfClient implements Closeable, Client {
                     throw new IllegalArgumentException("Event URL is null or empty");
                 }
                 threadExecutor.submit(() -> {
-                    sdkThread.waitForInitialization(0);
+                    boolean result = sdkThread.waitForInitialization(configuration.getInitialzationTimeout());
                     metricsThread = new AnalyticsManager(context, configuration, target, new AnalyticsPublisherService(configuration, sdkThread.getBearerToken(), sdkThread.getAuthInfo()));
                 });
             }
@@ -116,15 +116,24 @@ public class CfClient implements Closeable, Client {
     }
 
     @Override
+    public boolean waitForInitialization() {
+        if (sdkThread == null) throw new IllegalStateException("SDK not initialized");
+        return sdkThread.waitForInitialization(configuration.getInitialzationTimeout());
+    }
+
+    /**
+     * @deprecated
+     * Since 2.0.2, use zero args  {@link #waitForInitialization()} ()}instead and set the
+     * timeout using `CfConfiguration` builder `setInitializationTimeout`.  The `timeoutMS` will
+     * be ignored in this method and will solely look for the the config option. If this is not set,
+     * then SDK initialization will not timeout.
+     *
+     * Will be removed in a future release
+     */
+    @Override
     public boolean waitForInitialization(long timeoutMs) {
         if (sdkThread == null) throw new IllegalStateException("SDK not initialized");
         return sdkThread.waitForInitialization(timeoutMs);
-    }
-
-    @Override
-    public void waitForInitialization() throws InterruptedException {
-        if (sdkThread == null) throw new IllegalStateException("SDK not initialized");
-        sdkThread.waitForInitialization(0L);
     }
 
     @Override

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -114,7 +114,7 @@ public class CfClient implements Closeable, Client {
             log.warn(e.getMessage(), e);
         }
     }
-
+    
     @Override
     public boolean waitForInitialization() {
         if (sdkThread == null) throw new IllegalStateException("SDK not initialized");

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -57,6 +57,13 @@ public class CfClient implements Closeable, Client {
     }
 
     @Override
+    public void initialize(final Context context, final String apiKey, final CfConfiguration config,
+                           final Target target, final AuthCallback authCallback) throws IllegalStateException {
+        initializeInternal(context, apiKey, config, target, null, authCallback);
+    }
+
+
+    @Override
     public void initialize(
             final Context context,
             final String apiKey,
@@ -97,8 +104,10 @@ public class CfClient implements Closeable, Client {
                 if (isEmpty(configuration.getEventURL())) {
                     throw new IllegalArgumentException("Event URL is null or empty");
                 }
-                sdkThread.waitForInitialization(0);
-                metricsThread = new AnalyticsManager(context, configuration, target, new AnalyticsPublisherService(configuration, sdkThread.getBearerToken(), sdkThread.getAuthInfo()));
+                threadExecutor.submit(() -> {
+                    sdkThread.waitForInitialization(0);
+                    metricsThread = new AnalyticsManager(context, configuration, target, new AnalyticsPublisherService(configuration, sdkThread.getBearerToken(), sdkThread.getAuthInfo()));
+                });
             }
 
         } catch (Exception e) {
@@ -268,13 +277,6 @@ public class CfClient implements Closeable, Client {
     public void initialize(final Context context, final String apiKey, final CfConfiguration config,
             final Target target, final CloudCache cloudCache, @Nullable final AuthCallback authCallback) throws IllegalStateException {
         initializeInternal(context, apiKey, config, target, cloudCache, authCallback);
-    }
-
-    @Deprecated
-    @Override
-    public void initialize(final Context context, final String apiKey, final CfConfiguration config,
-                           final Target target, final AuthCallback authCallback) throws IllegalStateException {
-        initializeInternal(context, apiKey, config, target, null, authCallback);
     }
 
     @Deprecated

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
@@ -15,6 +15,7 @@ public class CfConfiguration {
     public static final int DEFAULT_METRICS_CAPACITY = 1024;
     public static final int MIN_METRICS_PUBLISHING_INTERVAL_IN_SECONDS = 60;
     public static final int DEFAULT_METRICS_PUBLISHING_ACCEPTABLE_DURATION_IN_SECONDS = 10;
+    public static final int DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLISECONDS = 0;
 
     private static final String BASE_URL = "https://config.ff.harness.io/api/1.0";
     private static final String EVENT_URL = "https://events.ff.harness.io/api/1.0";
@@ -35,6 +36,7 @@ public class CfConfiguration {
     private boolean debugEnabled;
 
     private CloudCache cache;
+    private int initialzationTimeout;
 
     protected CfConfiguration(
 
@@ -59,6 +61,7 @@ public class CfConfiguration {
         this.metricsPublishingIntervalInMillis = MIN_METRICS_PUBLISHING_INTERVAL_IN_SECONDS * 1000L;
         this.metricsServiceAcceptableDurationInMillis = DEFAULT_METRICS_PUBLISHING_ACCEPTABLE_DURATION_IN_SECONDS * 1000L;
         this.cache = null;
+        this.initialzationTimeout = DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLISECONDS;
     }
 
     public String getBaseURL() {
@@ -119,6 +122,9 @@ public class CfConfiguration {
     public CloudCache getCache() {
         return cache;
     }
+    public int getInitialzationTimeout() {
+        return initialzationTimeout;
+    }
 
     public static class Builder {
 
@@ -135,6 +141,7 @@ public class CfConfiguration {
         private boolean debugEnabled = false;
 
         private CloudCache cache = null;
+        private int initialzationTimeout = DEFAULT_INITIALIZATION_TIMEOUT_IN_MILLISECONDS;
 
         /**
          * Sets the base API url
@@ -267,6 +274,11 @@ public class CfConfiguration {
             return this;
         }
 
+        public Builder initialzationTimeout(int initialzationTimeout) {
+            this.initialzationTimeout = initialzationTimeout;
+            return this;
+        }
+
         public int getMetricsCapacity() {
 
             return metricsCapacity;
@@ -325,6 +337,10 @@ public class CfConfiguration {
             return cache;
         }
 
+        public int getInitialzationTimeout(){
+            return initialzationTimeout;
+        }
+
         /**
          * Build the configuration instance.
          *
@@ -357,6 +373,7 @@ public class CfConfiguration {
             cfConfiguration.setMetricsServiceAcceptableDurationInMillis(metricsPublishingAcceptableDurationInMillis);
             cfConfiguration.setDebugEnabled(debugEnabled);
             cfConfiguration.setCache(cache);
+            cfConfiguration.setInitialzationTimeout(initialzationTimeout);
             return cfConfiguration;
         }
     }
@@ -397,6 +414,10 @@ public class CfConfiguration {
 
     public void setDebugEnabled(boolean enabled) {
         this.debugEnabled = enabled;
+    }
+
+    public void setInitialzationTimeout(int initialzationTimeout) {
+        this.initialzationTimeout = initialzationTimeout;
     }
 
     void setCache(CloudCache cache) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/Client.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/Client.java
@@ -14,6 +14,9 @@ import io.harness.cfsdk.cloud.sse.EventsListener;
 
 public interface Client extends AutoCloseable {
 
+    void initialize(final Context context, final String apiKey, final CfConfiguration config,
+                    final Target target, final AuthCallback authCallback) throws IllegalStateException;
+
     void initialize(
             Context context,
             String apiKey,
@@ -24,6 +27,7 @@ public interface Client extends AutoCloseable {
 
     /**
      * Wait for the SDK to authenticate and populate its cache.
+     *
      * @param timeoutMs Timeout in milliseconds to wait for SDK to initialize
      * @return Returns true if successfully initialized else false if timed out or something went
      * wrong. If false is returned, your code may proceed to use xVariation functions however
@@ -35,6 +39,7 @@ public interface Client extends AutoCloseable {
     /**
      * Wait for the SDK to authenticate and populate it cache. This version waits indefinitely, if
      * you require control over startup time then use {@link #waitForInitialization(long) waitForInitialization(timeoutMs)}
+     *
      * @throws InterruptedException if the thread was interrupted while waiting
      * @since 1.2.0
      */
@@ -42,6 +47,7 @@ public interface Client extends AutoCloseable {
 
     /**
      * Retrieve the current state of a boolean feature flag
+     *
      * @param evaluationId The identifier of the flag as configured in the UI.
      * @param defaultValue A default value to return if an error is detected or SDK is not
      *                     authenticated.
@@ -51,6 +57,7 @@ public interface Client extends AutoCloseable {
 
     /**
      * Retrieve the current state of a string feature flag
+     *
      * @param evaluationId The identifier of the flag as configured in the UI.
      * @param defaultValue A default value to return if an error is detected or SDK is not
      *                     authenticated.
@@ -60,6 +67,7 @@ public interface Client extends AutoCloseable {
 
     /**
      * Retrieve the current state of a number feature flag
+     *
      * @param evaluationId The identifier of the flag as configured in the UI.
      * @param defaultValue A default value to return if an error is detected or SDK is not
      *                     authenticated.
@@ -69,6 +77,7 @@ public interface Client extends AutoCloseable {
 
     /**
      * Retrieve the current state of a JSON feature flag
+     *
      * @param evaluationId The identifier of the flag as configured in the UI.
      * @param defaultValue A default value to return if an error is detected or SDK is not
      *                     authenticated.
@@ -124,6 +133,7 @@ public interface Client extends AutoCloseable {
      * Clears the occupied resources and shut's down the sdk.
      * After calling this method, the {@link #initialize} must be called again. It will also
      * remove any registered event listeners.
+     *
      * @since 1.2.0
      */
     void close();
@@ -136,17 +146,7 @@ public interface Client extends AutoCloseable {
      */
     @Deprecated
     void initialize(final Context context, final String apiKey, final CfConfiguration config,
-                           final Target target, final CloudCache cloudCache, @Nullable final AuthCallback authCallback) throws IllegalStateException;
-
-
-    /**
-     * Deprecated. Use {@link io.harness.cfsdk.CfClient#initialize(Context, String, CfConfiguration, Target)} instead.
-     * Kept for source compatibility with 1.x.x projects and will be removed in a future version.
-     * Authentication callback has been removed you should instead wait for authentication to complete using {@link CfClient#waitForInitialization()}.
-     */
-    @Deprecated
-    void initialize(final Context context, final String apiKey, final CfConfiguration config,
-                           final Target target, final AuthCallback authCallback) throws IllegalStateException;
+                    final Target target, final CloudCache cloudCache, @Nullable final AuthCallback authCallback) throws IllegalStateException;
 
 
     /**
@@ -156,6 +156,6 @@ public interface Client extends AutoCloseable {
      */
     @Deprecated
     void initialize(final Context context, final String apiKey, final CfConfiguration config,
-                           final Target target, final CloudCache cloudCache) throws IllegalStateException;
+                    final Target target, final CloudCache cloudCache) throws IllegalStateException;
 
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/Client.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/Client.java
@@ -38,7 +38,7 @@ public interface Client extends AutoCloseable {
      * @throws InterruptedException if the thread was interrupted while waiting
      * @since 1.2.0
      */
-    void waitForInitialization() throws InterruptedException;
+    boolean waitForInitialization() throws InterruptedException;
 
     /**
      * Retrieve the current state of a boolean feature flag

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -151,7 +151,7 @@ class SdkThread implements Runnable {
         try {
             bearerToken = api.authenticate(authRequest).getAuthToken();
         } catch (ApiException ex) {
-            // 1.x.x backwards compatibility - this catch can be removed once the deprecated AuthCallback and AuthResult are removed
+            // If AuthCallBack is being used to initialize the SDK
             if (authCallback != null && ex.getCode() != 200) {
                 authCallback.authorizationSuccess(null, new AuthResult(false, ex));
             }

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -472,6 +472,36 @@ class SdkThread implements Runnable {
         }
     }
 
+    boolean waitForInitialization() {
+        try {
+            SdkCodes.infoSdkWaitingForInit();
+
+            int timeoutMs = config.getInitialzationTimeout();
+            if (timeoutMs <= 0) {
+                initLatch.await();
+                return true;
+            }
+
+            if (initLatch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                return true;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            logExceptionAndWarn("waitForInit interrupted", e);
+        }
+        log.warn("Failed to initialize within the {}ms timeout window. Defaults will be served.", config.getInitialzationTimeout());
+        return false;
+    }
+
+    /**
+     * @deprecated
+     * Since 2.0.2, use zero args  {@link #waitForInitialization()} ()}instead and set the
+     * timeout using `CfConfiguration` builder `setInitializationTimeout`.  The `timeoutMS` will
+     * be ignored in this method and will solely look for the the config option. If this is not set,
+     * then SDK initialization will not timeout.
+     *
+     * Will be removed in a future release
+     */
     boolean waitForInitialization(long timeoutMs) {
         try {
             SdkCodes.infoSdkWaitingForInit();

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -472,36 +472,7 @@ class SdkThread implements Runnable {
         }
     }
 
-    boolean waitForInitialization() {
-        try {
-            SdkCodes.infoSdkWaitingForInit();
 
-            int timeoutMs = config.getInitialzationTimeout();
-            if (timeoutMs <= 0) {
-                initLatch.await();
-                return true;
-            }
-
-            if (initLatch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
-                return true;
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logExceptionAndWarn("waitForInit interrupted", e);
-        }
-        log.warn("Failed to initialize within the {}ms timeout window. Defaults will be served.", config.getInitialzationTimeout());
-        return false;
-    }
-
-    /**
-     * @deprecated
-     * Since 2.0.2, use zero args  {@link #waitForInitialization()} ()}instead and set the
-     * timeout using `CfConfiguration` builder `setInitializationTimeout`.  The `timeoutMS` will
-     * be ignored in this method and will solely look for the the config option. If this is not set,
-     * then SDK initialization will not timeout.
-     *
-     * Will be removed in a future release
-     */
     boolean waitForInitialization(long timeoutMs) {
         try {
             SdkCodes.infoSdkWaitingForInit();

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthCallback.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthCallback.java
@@ -2,12 +2,6 @@ package io.harness.cfsdk.cloud.events;
 
 import io.harness.cfsdk.cloud.model.AuthInfo;
 
-/**
- * This class will be removed in a future version of the SDK.
- * Use {@link io.harness.cfsdk.CfClient#waitForInitialization()} instead to wait for authentication
- * and flag cache loading to complete.
- */
-@Deprecated
 public interface AuthCallback {
 
     void authorizationSuccess(AuthInfo authInfo, AuthResult result);


### PR DESCRIPTION
# What
In V2 of the SDK, the `AuthCallback` API to initialize the SDK was deprecated in favour of using a new API which can be used with `waitForInitialzation` 

There was a bug in the new API which meant that if it was used to initialise the SDK, and the SDK failed to initialise, it would never return control back to the users code. 

This fixes that by introducing a new timeout option to the client configuration, which defaults to no timeout, and is also used by `waitForInitialzation` calls



