### PR TITLE
[FFM-10903] - CVE-2023-3635: update okhttp/okio-jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ buildscript {
 
 In app module's [build.gradle](https://github.com/harness/ff-android-client-sdk/blob/main/examples/GettingStarted/app/build.gradle#L41) file add dependency for Harness's SDK
 
-`implementation 'io.harness:ff-android-client-sdk:2.0.0'`
+`implementation 'io.harness:ff-android-client-sdk:2.0.2'`
 
 
 ### Code Sample

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ value update.
 
 <br>
 
+### Client Initialzation 
+For more information on initialzation options, see [Client Initialzation Options](docs/further_reading.md#client-initialization-options)<br>
+
+
 ### Release builds and ProGuard
 For release builds, Android uses ProGuard to apply optimizations that can affect the behavior of the SDK.
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,9 @@ allprojects {
     apply plugin: 'org.owasp.dependencycheck'
 
       dependencyCheck {
+
+        nvd.apiKey = project.findProperty("FF_NVD_API_KEY")
+
         format = "JSON"
         analyzers {
             // full list https://jeremylong.github.io/DependencyCheck/dependency-check-gradle/configuration.html

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ buildscript {
         classpath 'com.android.tools:r8:8.2.42'
         classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.owasp:dependency-check-gradle:9.0.7'
+        classpath 'org.owasp:dependency-check-gradle:9.0.9'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,8 +2,8 @@
 buildscript {
 
     ext {
-        kotlin_version = "1.7.20"
-        okhttp3_version = "4.11.0"
+        kotlin_version = "1.9.10"
+        okhttp3_version = "4.12.0"
     }
 
     repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -18,13 +18,13 @@ buildscript {
         classpath 'com.android.tools:r8:8.2.42'
         classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.owasp:dependency-check-gradle:8.4.3'
+        classpath 'org.owasp:dependency-check-gradle:9.0.7'
     }
 }
 
 allprojects {
 
-    configurations.all {
+   configurations.all {
         resolutionStrategy {
             force "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
             force "org.jetbrains.kotlin:kotlin-stdlib-common:$kotlin_version"

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:8.4.0'
+    classpath 'org.owasp:dependency-check-gradle:9.0.7'
   }
 }
 

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath 'org.owasp:dependency-check-gradle:9.0.7'
+    classpath 'org.owasp:dependency-check-gradle:9.0.9'
   }
 }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.0.1";
+    public static final String ANDROID_SDK_VERSION = "2.0.2";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -108,6 +108,10 @@ public class CfClient implements Closeable, Client {
 
     @Override
     public boolean waitForInitialization(long timeoutMs) {
+        if (timeoutMs < 2000) {
+            timeoutMs = 2000;
+        }
+
         if (sdkThread == null) throw new IllegalStateException("SDK not initialized");
         return sdkThread.waitForInitialization(timeoutMs);
     }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -270,7 +270,6 @@ public class CfClient implements Closeable, Client {
         initializeInternal(context, apiKey, config, target, cloudCache, authCallback);
     }
 
-    @Deprecated
     @Override
     public void initialize(final Context context, final String apiKey, final CfConfiguration config,
                            final Target target, final AuthCallback authCallback) throws IllegalStateException {

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -164,8 +164,14 @@ public class CfClient implements Closeable, Client {
         return eventsListenerSet.remove(observer);
     }
 
+
     @Override
     public boolean boolVariation(String evaluationId, boolean defaultValue) {
+        if (sdkThread == null) {
+            SdkCodes.warnDefaultVariationServed(evaluationId, String.valueOf(defaultValue), "initialize() not called");
+            return defaultValue;
+        }
+
         final StringBuilder failureReason = new StringBuilder();
         final Evaluation evaluation = sdkThread.getEvaluationById(evaluationId, failureReason);
 
@@ -184,6 +190,11 @@ public class CfClient implements Closeable, Client {
 
     @Override
     public String stringVariation(String evaluationId, String defaultValue) {
+        if (sdkThread == null) {
+            SdkCodes.warnDefaultVariationServed(evaluationId, String.valueOf(defaultValue), "initialize() not called");
+            return defaultValue;
+        }
+
         final StringBuilder failureReason = new StringBuilder();
         final Evaluation evaluation = sdkThread.getEvaluationById(evaluationId, failureReason);
 
@@ -202,6 +213,11 @@ public class CfClient implements Closeable, Client {
 
     @Override
     public double numberVariation(String evaluationId, double defaultValue) {
+        if (sdkThread == null) {
+            SdkCodes.warnDefaultVariationServed(evaluationId, String.valueOf(defaultValue), "initialize() not called");
+            return defaultValue;
+        }
+
         final StringBuilder failureReason = new StringBuilder();
         final Evaluation evaluation = sdkThread.getEvaluationById(evaluationId, failureReason);
 
@@ -227,6 +243,11 @@ public class CfClient implements Closeable, Client {
 
     @Override
     public JSONObject jsonVariation(String evaluationId, JSONObject defaultValue) {
+        if (sdkThread == null) {
+            SdkCodes.warnDefaultVariationServed(evaluationId, String.valueOf(defaultValue), "initialize() not called");
+            return defaultValue;
+        }
+
         final StringBuilder failureReason = new StringBuilder();
         final Evaluation evaluation = sdkThread.getEvaluationById(evaluationId, failureReason);
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/Client.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/Client.java
@@ -14,6 +14,17 @@ import io.harness.cfsdk.cloud.sse.EventsListener;
 
 public interface Client extends AutoCloseable {
 
+    /**
+     * Initialize the SDK.
+     * If using this call you should generally call {@link #waitForInitialization(long) waitForInitialization(timeoutMs)} afterwards to block the calling
+     * thread to ensure that authentication has completed. Or else you may get default variations served. Alternatively if you don't want to block with
+     * waitForInitialization(...) you can use the callback version here {@link CfClient#initialize(Context, String, CfConfiguration, Target, AuthCallback)}
+     * @param context The application context, used for any Android-specific initialization (not null).
+     * @param apiKey The API key required to authenticate with the service (not null or empty).
+     * @param configuration The configuration settings for the SDK, including endpoints and feature flags (not null).
+     * @param target The target user or entity for which feature flags and configurations will be evaluated (not null).
+     * @throws IllegalStateException if the SDK has already been initialized or if any preconditions are not met (e.g., null parameters).
+     */
     void initialize(
             Context context,
             String apiKey,
@@ -23,8 +34,11 @@ public interface Client extends AutoCloseable {
     ) throws IllegalStateException;
 
     /**
-     * Wait for the SDK to authenticate and populate its cache.
-     * @param timeoutMs Timeout in milliseconds to wait for SDK to initialize
+     * Wait for the SDK to authenticate and populate its cache. This version blocks the calling thread until timeoutMs elapses.
+     * Alternatively if you prefer not to block the calling thread you can provide a callback via
+     * {@link CfClient#initialize(Context, String, CfConfiguration, Target, AuthCallback)} to be notified when the SDK is ready.
+     * @param timeoutMs Timeout in milliseconds to wait for SDK to initialize. Try to avoid setting this to very low values (below
+     *                  2 seconds) as network conditions can affect the time it takes to authenticate.
      * @return Returns true if successfully initialized else false if timed out or something went
      * wrong. If false is returned, your code may proceed to use xVariation functions however
      * default variations may be served (SDKCODE 2001). For failure cause check logs leading up.
@@ -33,7 +47,7 @@ public interface Client extends AutoCloseable {
     boolean waitForInitialization(long timeoutMs);
 
     /**
-     * Wait for the SDK to authenticate and populate it cache. This version waits indefinitely, if
+     * Wait for the SDK to authenticate and populate it cache. This version blocks the calling thread and waits indefinitely, if
      * you require control over startup time then use {@link #waitForInitialization(long) waitForInitialization(timeoutMs)}
      * @throws InterruptedException if the thread was interrupted while waiting
      * @since 1.2.0
@@ -140,14 +154,15 @@ public interface Client extends AutoCloseable {
 
 
     /**
-     * Deprecated. Use {@link io.harness.cfsdk.CfClient#initialize(Context, String, CfConfiguration, Target)} instead.
-     * Kept for source compatibility with 1.x.x projects and will be removed in a future version.
-     * Authentication callback has been removed you should instead wait for authentication to complete using {@link CfClient#waitForInitialization()}.
+     * Initialize the SDK with an {@link io.harness.cfsdk.cloud.events.AuthCallback}.
+     * Same as {@link CfClient#initialize(Context, String, CfConfiguration, Target)} but with a callback parameter.
+     * You can use this initialize function to provide a lambda that will be called when authentication completes instead
+     * of using {@link CfClient#waitForInitialization()}. The callback may be called on the context of the internal SDK thread
+     * and you should avoid blocking this for too long and exit the callback quickly.
+     * You might get multiple {@link io.harness.cfsdk.cloud.events.AuthResult} (set to false) if there was a failure and the SDK attempts to retry authentication.
      */
-    @Deprecated
     void initialize(final Context context, final String apiKey, final CfConfiguration config,
                            final Target target, final AuthCallback authCallback) throws IllegalStateException;
-
 
     /**
      * Deprecated. Use {@link io.harness.cfsdk.CfClient#initialize(Context, String, CfConfiguration, Target)} instead.

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthCallback.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthCallback.java
@@ -2,12 +2,6 @@ package io.harness.cfsdk.cloud.events;
 
 import io.harness.cfsdk.cloud.model.AuthInfo;
 
-/**
- * This class will be removed in a future version of the SDK.
- * Use {@link io.harness.cfsdk.CfClient#waitForInitialization()} instead to wait for authentication
- * and flag cache loading to complete.
- */
-@Deprecated
 public interface AuthCallback {
 
     void authorizationSuccess(AuthInfo authInfo, AuthResult result);

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthResult.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/events/AuthResult.java
@@ -1,10 +1,5 @@
 package io.harness.cfsdk.cloud.events;
 
-/**
- * Authentication result.
- * This class will be removed in a future version of the SDK.
- */
-@Deprecated
 public class AuthResult {
 
     private boolean success;

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NetworkInfoProviding.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NetworkInfoProviding.java
@@ -1,11 +1,12 @@
 package io.harness.cfsdk.cloud.network;
 
-import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 public abstract class NetworkInfoProviding {
 
     protected volatile boolean lastState;
-    protected final HashSet<NetworkListener> evaluationsObserver = new HashSet<>();
+    protected final Set<NetworkListener> evaluationsObserver = ConcurrentHashMap.newKeySet();
 
     public abstract boolean isNetworkAvailable();
 

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -370,7 +370,7 @@ public class CfClientTest {
                 when(config.getEventURL()).thenReturn(url);
                 when(config.isAnalyticsEnabled()).thenReturn(true);
                 when(config.isStreamEnabled()).thenReturn(true);
-                when(config.getMetricsPublishingIntervalInMillis()).thenReturn(1000L); // Force the publish time to be within the timeout
+                when(config.getMetricsPublishingIntervalInMillis()).thenReturn(5000L); // Force the publish time to be within the timeout
                 when(config.getMetricsCapacity()).thenReturn(DEFAULT_METRICS_CAPACITY);
                 when(config.getTlsTrustedCAs()).thenReturn(Collections.singletonList(localCert.certificate()));
                 when(config.getCache()).thenReturn(makeMockCache());
@@ -383,10 +383,11 @@ public class CfClientTest {
                         DUMMY_TARGET
                 );
 
-                for (int i = 0; i < 10; i++) {
+                for (int i = 0; i < 100; i++) {
                     client.boolVariation("anyone@anywhere.com", false); // need at least 1 eval for metrics to push
-                    MILLISECONDS.sleep(100);
+                    MILLISECONDS.sleep(10);
                 }
+
                 assertTrue(client.waitForInitialization(30_000));
 
                 dispatcher.assertEndpointConnectionOrTimeout(30, MockWebServerDispatcher.AUTH_ENDPOINT);

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -383,12 +383,11 @@ public class CfClientTest {
                         DUMMY_TARGET
                 );
 
-                assertTrue(client.waitForInitialization(30_000));
-
                 for (int i = 0; i < 10; i++) {
                     client.boolVariation("anyone@anywhere.com", false); // need at least 1 eval for metrics to push
                     MILLISECONDS.sleep(100);
                 }
+                assertTrue(client.waitForInitialization(30_000));
 
                 dispatcher.assertEndpointConnectionOrTimeout(30, MockWebServerDispatcher.AUTH_ENDPOINT);
                 dispatcher.assertEndpointConnectionOrTimeout(30, MockWebServerDispatcher.STREAM_ENDPOINT);

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -4,29 +4,37 @@ Covers advanced topics (different config options and scenarios)
 
 ## Client Initialization Options
 ### Overview
-The Harness Feature Flags SDK for Android supports flexible initialization strategies to accommodate different application startup requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK, 
-ensuring that feature flag evaluations are ready when you need them.
+The Harness Feature Flags SDK for Android supports flexible initialization strategies to accommodate different application startup requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK. 
 
 ### Asynchronous (Non-Blocking) Initialization
-To avoid blocking the main thread, especially important for UI applications, the SDK provides an asynchronous initialization option. This method allows your application to remain responsive while the SDK initializes in the background.
+To avoid blocking the main thread, especially important for UI applications, the SDK provides asynchronous initialization options. This method allows your application to remain responsive while the SDK initializes in the background.
 
+#### Using callback
 Usage:
 
 ```Kotlin
-            CfClient.getInstance().initialize(this, "apiKey", sdkConfiguration, target)
-            { info, result ->
-                if (result.isSuccess) {
-                    Log.i("SDKInit", "Successfully initialized client: " + info)
-            }  else {
-                    Log.e("SDKInit", "Failed to initialize client", result.error)
-                    result.error.message?.let { printMessage(it) }
-                } }
+val client = CfClient()
+client.initialize(this, apiKey, sdkConfiguration, target)
+{ info, result ->
+    if (result.isSuccess) {
+        Log.i("SDKInit", "Successfully initialized client: " + info)
+}  else {
+        Log.e("SDKInit", "Failed to initialize client", result.error)
+    } 
+}
 ```
 This non-blocking approach utilizes a callback to notify the application of the SDK's readiness or any errors encountered during initialization.
 * You might get multiple callbacks if there was a failure and the SDK attempts to retry authentication.
 
+#### Without using a callback
+If you don't want to use a callback, you can simply initialize the SDK. Defaults will be served for any variation calls until the SDK can complete initialization.
+```Kotlin
+val client = CfClient()
+client.initialize(this, apiKey, sdkConfiguration, target)
+```
 
-Synchronous (Blocking) Initialization
+
+### Synchronous (Blocking) Initialization
 For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method. 
 This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward. 
 
@@ -37,6 +45,11 @@ Usage:
 ```kotlin
 client.initialize(context, apiKey, configuration, target);
 boolean isInitialized = client.waitForInitialization(timeoutMs);
+if (isInitialized) {
+    Log.i("SDKInit", "Successfully initialized client)
+}  else {
+    Log.e("SDKInit", "Failed to initialize client")
+} 
 ```
 
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -4,10 +4,10 @@ Covers advanced topics (different config options and scenarios)
 
 ## Client Initialization Options
 ### Overview
-The Harness Feature Flags SDK for Android supports flexible initialization strategies to accommodate different application startup requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK. 
+The Harness Feature Flags SDK for Android supports flexible initialization strategies to accommodate different application startup requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK.
 
 ### Asynchronous (Non-Blocking) Initialization
-To avoid blocking the main thread, especially important for UI applications, the SDK provides asynchronous initialization options. This method allows your application to remain responsive while the SDK initializes in the background.
+To avoid blocking the main thread, the SDK provides asynchronous initialization options. This method allows your application to remain responsive while the SDK initializes in the background.
 
 #### Using callback
 Usage:
@@ -35,10 +35,10 @@ client.initialize(this, apiKey, sdkConfiguration, target)
 
 
 ### Synchronous (Blocking) Initialization
-For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method. 
-This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward. 
+For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method.
+This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward.
 
-This will block the UI thread, so use synchros initialization only if absolutely required. 
+This will block the UI thread, so use synchros initialization only if absolutely required.
 
 Usage:
 
@@ -53,17 +53,8 @@ if (isInitialized) {
 ```
 
 
-After invoking `initialize(...)`, calling waitForInitialization(long timeoutMs) blocks the calling thread until the SDK completes its authentication process or until the specified timeout elapses. A timeoutMs value of 0 waits indefinitely. 
+After invoking `initialize(...)`, calling `waitForInitialization(long timeoutMs)` blocks the calling thread until the SDK completes its authentication process or until the specified timeout elapses. A timeoutMs value of 0 waits indefinitely.
 Use this method cautiously to prevent blocking the main UI thread, which can lead to a poor user experience.
-
-
-### Choosing the Right Approach
-Blocking Initialization is suitable for backend services or applications where ensuring feature flag availability before proceeding is crucial.
-Non-Blocking Initialization is recommended for user-facing applications where maintaining a responsive UI is critical. This approach allows feature flag evaluations to proceed with default values until the SDK is fully initialized.
-Additional Considerations
-Cached Flag Data: If the SDK has cached flag data from a previous execution, variation methods will return cached data until fresh data is fetched.
-Timeouts: Set a reasonable timeout for blocking initialization to avoid extended delays, especially under poor network conditions.
-Thread Management: Avoid calling blocking initialization on the main UI thread. Utilize background threads or the SDK's asynchronous initialization to enhance user experience.
 
 
 ## Configuration Options
@@ -72,12 +63,12 @@ You can provide options by adding them to the SDK Configuration.
 
 ```Kotlin
         val sdkConfiguration = CfConfiguration.builder()
-            .baseUrl("https://config.ff.harness.io/api/1.0")
-            .eventUrl("https://events.ff.harness.io/api/1.0")
-            .pollingInterval(60)
-            .enableStream(true)
-            .enableAnalytics(true)
-            .build()
+    .baseUrl("https://config.ff.harness.io/api/1.0")
+    .eventUrl("https://events.ff.harness.io/api/1.0")
+    .pollingInterval(60)
+    .enableStream(true)
+    .enableAnalytics(true)
+    .build()
 ```
 
 
@@ -148,10 +139,10 @@ val target = Target().identifier("target")
 CfClient.getInstance().initialize(context, "YOUR_API_KEY", sdkConfiguration, target)
 
 if (CfClient.getInstance().waitForInitialization(15_000)) {
-        // Congratulations your SDK has been initialized with success!
-        // After this callback is executed, You are ready to use the SDK!                        
+    // Congratulations your SDK has been initialized with success!
+    // After this callback is executed, You are ready to use the SDK!                        
 } else {
-        // Timeout - check logcat for reason - SDK will attempt to reauthenticate in the background and serve defaults in the mean time
+    // Timeout - check logcat for reason - SDK will attempt to reauthenticate in the background and serve defaults in the mean time
 }
 ```
 
@@ -252,11 +243,11 @@ Triggered event will have one of the following types:
 
 ```Java
 public enum EVENT_TYPE {
-        SSE_START, 
-        SSE_RESUME
-        SSE_END, 
-        EVALUATION_CHANGE,
-        EVALUATION_RELOAD
+    SSE_START,
+    SSE_RESUME
+    SSE_END,
+    EVALUATION_CHANGE,
+    EVALUATION_RELOAD
     }
 ```
 Following table provides summary on possible event types and corresponding responses.
@@ -278,11 +269,11 @@ To avoid unexpected behaviour, when listener is not needed anymore, a caller sho
 Metrics API endpoint can be changed like this:
 ```kotlin
 val remoteConfiguration = CfConfiguration.builder()
-            .enableStream(true)
-            .pollingInterval(60)
-            .enableAnalytics(true)
-            .eventUrl(METRICS_API_EVENTS_URL)
-            .build()
+    .enableStream(true)
+    .pollingInterval(60)
+    .enableAnalytics(true)
+    .eventUrl(METRICS_API_EVENTS_URL)
+    .build()
 ```
 
 Otherwise, the default metrics endpoint URL will be used.

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -2,6 +2,57 @@
 
 Covers advanced topics (different config options and scenarios)
 
+## Client Initialization Options
+### Overview
+The Harness Feature Flags SDK for Android supports flexible initialization strategies to accommodate different application startup requirements. You can choose between an asynchronous (non-blocking) or synchronous (blocking) approach to initialize the SDK, 
+ensuring that feature flag evaluations are ready when you need them.
+
+### Asynchronous (Non-Blocking) Initialization
+To avoid blocking the main thread, especially important for UI applications, the SDK provides an asynchronous initialization option. This method allows your application to remain responsive while the SDK initializes in the background.
+
+Usage:
+
+```Kotlin
+            CfClient.getInstance().initialize(this, "apiKey", sdkConfiguration, target)
+            { info, result ->
+                if (result.isSuccess) {
+                    Log.i("SDKInit", "Successfully initialized client: " + info)
+            }  else {
+                    Log.e("SDKInit", "Failed to initialize client", result.error)
+                    result.error.message?.let { printMessage(it) }
+                } }
+```
+This non-blocking approach utilizes a callback to notify the application of the SDK's readiness or any errors encountered during initialization.
+* You might get multiple callbacks if there was a failure and the SDK attempts to retry authentication.
+
+
+Synchronous (Blocking) Initialization
+For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method. 
+This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward. 
+
+This will block the UI thread, so use synchros initialization only if absolutely required. 
+
+Usage:
+
+```kotlin
+client.initialize(context, apiKey, configuration, target);
+boolean isInitialized = client.waitForInitialization(timeoutMs);
+```
+
+
+After invoking `initialize(...)`, calling waitForInitialization(long timeoutMs) blocks the calling thread until the SDK completes its authentication process or until the specified timeout elapses. A timeoutMs value of 0 waits indefinitely. 
+Use this method cautiously to prevent blocking the main UI thread, which can lead to a poor user experience.
+
+
+### Choosing the Right Approach
+Blocking Initialization is suitable for backend services or applications where ensuring feature flag availability before proceeding is crucial.
+Non-Blocking Initialization is recommended for user-facing applications where maintaining a responsive UI is critical. This approach allows feature flag evaluations to proceed with default values until the SDK is fully initialized.
+Additional Considerations
+Cached Flag Data: If the SDK has cached flag data from a previous execution, variation methods will return cached data until fresh data is fetched.
+Timeouts: Set a reasonable timeout for blocking initialization to avoid extended delays, especially under poor network conditions.
+Thread Management: Avoid calling blocking initialization on the main UI thread. Utilize background threads or the SDK's asynchronous initialization to enhance user experience.
+
+
 ## Configuration Options
 The following configuration options are available to control the behaviour of the SDK.
 You can provide options by adding them to the SDK Configuration.

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.0.1')
+            version('sdk', '2.0.2')
         }
     }
 }


### PR DESCRIPTION
**What**
Upgrade okhttp from 4.11.0 to 4.12.0
Java doc updates
Minor fixes

**Why**
Reports of the following CVE (gzip vulnerability) due to an old version of okio-jvm being brought in by okhttp

`okio-jvm-3.2.0.jar (pkg:maven/com.squareup.okio/okio-jvm@3.2.0, cpe:2.3:a:squareup:okio:3.2.0:*:*:*:*:*:*:*) : CVE-2023-3635`

**Testing**
Manual