### PR TITLE
FFM-10940 Enable no polling mode + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ buildscript {
 
 In app module's [build.gradle](https://github.com/harness/ff-android-client-sdk/blob/main/examples/GettingStarted/app/build.gradle#L41) file add dependency for Harness's SDK
 
-`implementation 'io.harness:ff-android-client-sdk:2.0.2'`
+`implementation 'io.harness:ff-android-client-sdk:2.1.0'`
 
 
 ### Code Sample

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.0.2";
+    public static final String ANDROID_SDK_VERSION = "2.1.0";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
@@ -25,6 +25,8 @@ public class CfConfiguration {
 
     private final boolean analyticsEnabled;
     private final boolean streamEnabled;
+    private boolean pollingEnabled;
+
 
     private int metricsCapacity;
     private final int pollingInterval;
@@ -44,7 +46,8 @@ public class CfConfiguration {
             boolean streamEnabled,
             boolean analyticsEnabled,
             int pollingInterval,
-            List<X509Certificate> tlsTrustedCerts
+            List<X509Certificate> tlsTrustedCerts,
+            boolean pollingEnabled
 
     ) {
 
@@ -59,6 +62,7 @@ public class CfConfiguration {
         this.metricsPublishingIntervalInMillis = MIN_METRICS_PUBLISHING_INTERVAL_IN_SECONDS * 1000L;
         this.metricsServiceAcceptableDurationInMillis = DEFAULT_METRICS_PUBLISHING_ACCEPTABLE_DURATION_IN_SECONDS * 1000L;
         this.cache = null;
+        this.pollingEnabled = pollingEnabled;
     }
 
     public String getBaseURL() {
@@ -87,6 +91,10 @@ public class CfConfiguration {
     public boolean isStreamEnabled() {
 
         return streamEnabled;
+    }
+
+    public boolean isPollingEnabled() {
+        return pollingEnabled;
     }
 
     /**
@@ -128,6 +136,7 @@ public class CfConfiguration {
         private int pollingInterval;
         private int metricsCapacity = DEFAULT_METRICS_CAPACITY;
         private boolean streamEnabled = true;
+        private boolean pollingEnabled = true;
         private boolean analyticsEnabled = true;
         private long metricsPublishingIntervalInMillis = MIN_METRICS_PUBLISHING_INTERVAL_IN_SECONDS * 1000L;
         private long metricsPublishingAcceptableDurationInMillis = DEFAULT_METRICS_PUBLISHING_ACCEPTABLE_DURATION_IN_SECONDS * 1000L;
@@ -197,6 +206,18 @@ public class CfConfiguration {
             this.streamEnabled = streamEnabled;
             return this;
         }
+
+        /**
+         * Configuration to explicitly enable or disable polling.
+         *
+         * @param pollingEnabled True == Polling is enabled.
+         * @return Builder instance.
+         */
+        public Builder enablePolling(boolean pollingEnabled) {
+            this.pollingEnabled = pollingEnabled;
+            return this;
+        }
+
 
         /**
          * Polling interval to use when getting new evaluation data from server
@@ -303,6 +324,11 @@ public class CfConfiguration {
             return streamEnabled;
         }
 
+        public boolean isPollingEnabled() {
+
+            return pollingEnabled;
+        }
+
         public boolean isAnalyticsEnabled() {
 
             return analyticsEnabled;
@@ -349,7 +375,7 @@ public class CfConfiguration {
 
             final CfConfiguration cfConfiguration = new CfConfiguration(
 
-                    baseURL, streamURL, eventURL, streamEnabled, analyticsEnabled, pollingInterval, tlsTrustedCerts
+                    baseURL, streamURL, eventURL, streamEnabled, analyticsEnabled, pollingInterval, tlsTrustedCerts, pollingEnabled
             );
 
             cfConfiguration.setMetricsCapacity(metricsCapacity);

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfConfiguration.java
@@ -27,7 +27,6 @@ public class CfConfiguration {
     private final boolean streamEnabled;
     private boolean pollingEnabled;
 
-
     private int metricsCapacity;
     private final int pollingInterval;
     private final List<X509Certificate> tlsTrustedCerts;

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -418,9 +418,12 @@ class SdkThread implements Runnable {
             Thread.currentThread().setName("RegisteredListenersThread");
             log.debug("send event {} to registered listeners", statusEvent.getEventType());
 
-            for (final EventsListener listener : eventsListenerSet) {
-                listener.onEventReceived(statusEvent);
+            synchronized(eventsListenerSet) {
+                for (final EventsListener listener : eventsListenerSet) {
+                    listener.onEventReceived(statusEvent);
+                }
             }
+
         });
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -543,7 +543,6 @@ class SdkThread implements Runnable {
             } catch (ApiException ex) {
                 if (ex.getCode() == 403) {
                     SdkCodes.warnAuthFailedSrvDefaults(ex.getMessage());
-                    log.error("Received a 403 Forbidden response. Stopping SDK re-authentication attempts and defaults will be served.", ex);
                     break;
                 } else {
                     logExceptionAndWarn("API exception encountered, SDK will be restarted in 1 minute:", ex);

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -540,6 +540,13 @@ class SdkThread implements Runnable {
                 }
                 waitForNetworkToGoOnline();
                 continue;
+            } catch (ApiException ex) {
+                if (ex.getCode() == 403) {
+                    log.error("Received a 403 Forbidden response. Stopping SDK re-authentication attempts and defaults will be served.", ex);
+                    break;
+                } else {
+                    logExceptionAndWarn("API exception encountered, SDK will attempt to restart:", ex);
+                }
             } catch (Throwable ex) {
                 logExceptionAndWarn("Root SDK exception handler invoked, SDK will be restarted in 1 minute:", ex);
             }

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -18,6 +18,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -418,12 +419,14 @@ class SdkThread implements Runnable {
             Thread.currentThread().setName("RegisteredListenersThread");
             log.debug("send event {} to registered listeners", statusEvent.getEventType());
 
-            for (final EventsListener listener : eventsListenerSet) {
-                listener.onEventReceived(statusEvent);
+            final List<EventsListener> toNotify;
+            synchronized (eventsListenerSet) {
+                toNotify = new ArrayList<>(eventsListenerSet);
             }
+
+            toNotify.forEach(l -> l.onEventReceived(statusEvent));
         });
     }
-
     Map<String, String> makeHeadersFrom(String token, String apiKey, AuthInfo authInfo) {
         return new HashMap<String, String>() {{
             put("Authorization", "Bearer " + token);

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -542,6 +542,7 @@ class SdkThread implements Runnable {
                 continue;
             } catch (ApiException ex) {
                 if (ex.getCode() == 403) {
+                    SdkCodes.warnAuthFailedSrvDefaults(ex.getMessage());
                     log.error("Received a 403 Forbidden response. Stopping SDK re-authentication attempts and defaults will be served.", ex);
                     break;
                 } else {

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -155,7 +155,7 @@ class SdkThread implements Runnable {
         try {
             bearerToken = api.authenticate(authRequest).getAuthToken();
         } catch (ApiException ex) {
-            if (authCallback != null && ex.getCode() != 200) {
+            if (authCallback != null && ex.getCode() != 200 && !isAuthSuccessfulOnce) {
                 authCallback.authorizationSuccess(null, new AuthResult(false, ex));
             }
             throw ex;

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -418,12 +418,9 @@ class SdkThread implements Runnable {
             Thread.currentThread().setName("RegisteredListenersThread");
             log.debug("send event {} to registered listeners", statusEvent.getEventType());
 
-            synchronized(eventsListenerSet) {
-                for (final EventsListener listener : eventsListenerSet) {
-                    listener.onEventReceived(statusEvent);
-                }
+            for (final EventsListener listener : eventsListenerSet) {
+                listener.onEventReceived(statusEvent);
             }
-
         });
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -111,7 +111,7 @@ class SdkThread implements Runnable {
             fallbackToPolling = true;
         }
 
-        if (fallbackToPolling) {
+        if (fallbackToPolling && config.isPollingEnabled()) {
             log.debug("SSE stream {}, falling back to polling mode", config.isStreamEnabled() ? "failed" : "disabled");
 
             try {

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -546,7 +546,7 @@ class SdkThread implements Runnable {
                     log.error("Received a 403 Forbidden response. Stopping SDK re-authentication attempts and defaults will be served.", ex);
                     break;
                 } else {
-                    logExceptionAndWarn("API exception encountered, SDK will attempt to restart:", ex);
+                    logExceptionAndWarn("API exception encountered, SDK will be restarted in 1 minute:", ex);
                 }
             } catch (Throwable ex) {
                 logExceptionAndWarn("Root SDK exception handler invoked, SDK will be restarted in 1 minute:", ex);

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -539,7 +539,16 @@ class SdkThread implements Runnable {
             } catch (Throwable ex) {
                 logExceptionAndWarn("Root SDK exception handler invoked, SDK will be restarted in 1 minute:", ex);
             }
-            /* should the sdk thread abort unexpectedly it will be restarted here */
+
+            /* should the sdk thread abort, it will conditionally be restarted here */
+
+            // If both streaming and polling are disabled, then we don't need the sdk thread to run anymore
+            if (!config.isStreamEnabled() && !config.isPollingEnabled()) {
+                log.info("Streaming and Polling are disabled. Initial setup complete. Exiting SDK main thread.");
+                break;
+            }
+
+            // Restart the thread here as it has aborted unexpectedly
             try {
                 TimeUnit.MINUTES.sleep(1);
             } catch (InterruptedException e) {

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfConfigurationTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfConfigurationTest.java
@@ -26,6 +26,7 @@ public class CfConfigurationTest {
                 .streamUrl("https://dummy_stream_url:1234")
                 .enableAnalytics(false)
                 .enableStream(false)
+                .enablePolling(false)
                 .pollingInterval(60)
                 .tlsTrustedCAs(Collections.singletonList(mockX509))
                 .metricsPublishingAcceptableDurationInMillis(1234)
@@ -39,6 +40,7 @@ public class CfConfigurationTest {
         assertEquals("https://dummy_stream_url:1234", config.getStreamURL());
         assertFalse(config.isAnalyticsEnabled());
         assertFalse(config.isStreamEnabled());
+        assertFalse(config.isPollingEnabled());
         assertEquals(60, config.getPollingInterval());
         assertEquals(1, config.getTlsTrustedCAs().size());
         assertNotNull(config.getTlsTrustedCAs().get(0));

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -56,6 +56,29 @@ if (isInitialized) {
 After invoking `initialize(...)`, calling `waitForInitialization(long timeoutMs)` blocks the calling thread until the SDK completes its authentication process or until the specified timeout elapses. A timeoutMs value of 0 waits indefinitely.
 Use this method cautiously to prevent blocking the main UI thread, which can lead to a poor user experience.
 
+## Streaming and Polling Mode
+
+By default, Harness Feature Flags SDK has streaming enabled and polling enabled. Both modes can be toggled according to your preference using the SDK's configuration.
+
+### Streaming Mode
+Streaming mode establishes a continuous connection between your application and the Feature Flags service.
+This allows for real-time updates on feature flags without requiring periodic checks.
+If an error occurs while streaming and `pollingEnabled` is set to `true`,
+the SDK will automatically fall back to polling mode until streaming can be reestablished.
+If `pollingEnabled` is `false`, streaming will attempt to reconnect without falling back to polling.
+
+### Polling Mode
+In polling mode, the SDK will periodically check with the Feature Flags service to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
+
+### No Streaming or Polling
+If both streaming and polling modes are disabled (`streamEnabled: false` and `pollingEnabled: false`),
+the SDK will not automatically fetch feature flag updates after the initial fetch.
+This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.
+
+This configuration might be useful in specific scenarios where you want to ensure a consistent set of feature flags
+for a session or when the application operates in an environment where regular updates are not necessary. However, it's essential to be aware that this configuration can lead to outdated flag evaluations if the flags change on the server.
+
+To configure the modes see [Configuration options](#configuration-options)
 
 ## Configuration Options
 The following configuration options are available to control the behaviour of the SDK.
@@ -67,6 +90,7 @@ You can provide options by adding them to the SDK Configuration.
     .eventUrl("https://events.ff.harness.io/api/1.0")
     .pollingInterval(60)
     .enableStream(true)
+    .enablePolling(true)
     .enableAnalytics(true)
     .build()
 ```

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -71,7 +71,7 @@ If `pollingEnabled` is `false`, streaming will attempt to reconnect without fall
 In polling mode, the SDK will periodically check with the Feature Flags service to retrieve updates for feature flags. The frequency of these checks can be adjusted using the SDK's configurations.
 
 ### No Streaming or Polling
-If both streaming and polling modes are disabled (`streamEnabled: false` and `pollingEnabled: false`),
+If both streaming and polling modes are disabled (`enableStream: false` and `enablePolling: false`),
 the SDK will not automatically fetch feature flag updates after the initial fetch.
 This means that after the initial load, any changes made to the feature flags on the Harness server will not be reflected in the application until the SDK is re-initialized or one of the modes is re-enabled.
 

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -23,8 +23,10 @@ client.initialize(this, apiKey, sdkConfiguration, target)
     } 
 }
 ```
-This non-blocking approach utilizes a callback to notify the application of the SDK's readiness or any errors encountered during initialization.
-* You might get multiple callbacks if there was a failure and the SDK attempts to retry authentication.
+This approach is non-blocking and leverages a callback mechanism to inform the application about the SDK's initialization status. Here's how it works:
+* Success Callback: This callback is invoked once when the SDK is successfully initialized. It signifies that the SDK is ready for use. 
+
+* Failure Callback: This callback may be invoked multiple times if the SDK encounters errors during the initialization process. Each invocation provides an error detailing the cause of failure. The SDK will automatically attempt to retry authentication, leading to multiple invocations of this callback until a successful initialization occurs or the application decides to stop retrying.
 
 #### Without using a callback
 If you don't want to use a callback, you can simply initialize the SDK. Defaults will be served for any variation calls until the SDK can complete initialization.

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -26,7 +26,7 @@ client.initialize(this, apiKey, sdkConfiguration, target)
 This approach is non-blocking and leverages a callback mechanism to inform the application about the SDK's initialization status. Here's how it works:
 * Success Callback: This callback is invoked once when the SDK is successfully initialized. It signifies that the SDK is ready for use. 
 
-* Failure Callback: This callback may be invoked multiple times if the SDK encounters errors during the initialization process. Each invocation provides an error detailing the cause of failure. The SDK will automatically attempt to retry authentication, leading to multiple invocations of this callback until a successful initialization occurs or the application decides to stop retrying.
+* Failure Callback: This callback may be invoked multiple times if the SDK encounters errors during the initialization process. Each invocation provides an error detailing the cause of failure. The SDK will automatically attempt to retry authentication, leading to multiple invocations of this callback until a successful initialization occurs.
 
 #### Without using a callback
 If you don't want to use a callback, you can simply initialize the SDK. Defaults will be served for any variation calls until the SDK can complete initialization.

--- a/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -36,7 +36,9 @@ class MainActivity : AppCompatActivity() {
     private fun initializeSdk(method: InitMethod) {
         logMessage("initializing SDK using ${method.toString().lowercase()}")
         // Common configuration and target setup
-        val sdkConfiguration = CfConfiguration.builder().enableStream(true).enablePolling(true).build()
+        val streamingEnabled = true
+        val pollingEnabled = true
+        val sdkConfiguration = CfConfiguration.builder().enableStream(streamingEnabled).enablePolling(pollingEnabled).build()
         val target = Target().identifier("ff-android").name("FF Android")
         target.attributes["location"] = "emea"
 
@@ -44,7 +46,10 @@ class MainActivity : AppCompatActivity() {
         client = CfClient()
 
         // Setup Listener to handle different events emitted by the SDK
-        setupEventListener()
+        // You only need to set this up if streaming/polling is enabled.
+        if (streamingEnabled && pollingEnabled) {
+            setupEventListener()
+        }
         
 
         when (method) {

--- a/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -25,6 +25,7 @@ class MainActivity : AppCompatActivity() {
     // e.g. FF_API_KEY='my key' ./gradlew installDebug
     private val apiKey: String = BuildConfig.FF_API_KEY
 
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -114,10 +115,15 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    // Highly likely to serve default value of `false` as the SDK will still be initializing.
+    // SDKCODE(eval:6001) will be logged if the default variation is served.
+    //
+    // However, if you subscribe to `EVALUATION_RELOAD` which is fired on successful init and then when the SDK
+    // polls, you can evaluate the flag there again to get the current value.
+    // eventually get the correct value
     private fun initializeNonBlocking(config: CfConfiguration, target: Target) {
         client.initialize(this, apiKey, config, target)
-        // Highly likely to serve default value of `false` as the SDK will still be initializing.
-        // Use callback approach of waitForInit
+
         val flagValue: Boolean = client.boolVariation(flagName, false)
         logMessage("Using callback: $flagName : $flagValue")
     }

--- a/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -120,7 +120,6 @@ class MainActivity : AppCompatActivity() {
     //
     // However, if you subscribe to `EVALUATION_RELOAD` which is fired on successful init and then when the SDK
     // polls, you can evaluate the flag there again to get the current value.
-    // eventually get the correct value
     private fun initializeNonBlocking(config: CfConfiguration, target: Target) {
         client.initialize(this, apiKey, config, target)
 

--- a/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun initializeSdk(method: InitMethod) {
-        logMessage("initializing SDK using ${method.toString().lowercase()}")
+        updateTextField("initializing SDK using ${method.toString().lowercase()}")
         // Common configuration and target setup
         val streamingEnabled = true
         val pollingEnabled = true
@@ -68,7 +68,7 @@ class MainActivity : AppCompatActivity() {
                 // Setup Listener to handle flag change events.  This fires when a flag is modified.
                 StatusEvent.EVENT_TYPE.EVALUATION_CHANGE-> {
                     flagValue = client.boolVariation(flagName, false)
-                    logMessage("Streamed value for $flagName : $flagValue")
+                    updateTextField("Streamed value for $flagName : $flagValue")
                 }
 
                 // This event is fired on the initial poll when the SDK starts up. So it will
@@ -77,14 +77,14 @@ class MainActivity : AppCompatActivity() {
                 // while streaming recovers from any errors.
                 StatusEvent.EVENT_TYPE.EVALUATION_RELOAD -> {
                     flagValue = client.boolVariation(flagName, false)
-                    logMessage("Polled value for $flagName : $flagValue")
+                    updateTextField("Polled value for $flagName : $flagValue")
                 }
                 // There's been an interruption SSE stream which has since resumed, which means the
                 // cache will have been updated with the latest values, so we can call
                 // bool variation to get the most up-to-date evaluation value.
                 StatusEvent.EVENT_TYPE.SSE_RESUME -> {
                     flagValue = client.boolVariation(flagName, false)
-                    logMessage("$flagName : $flagValue")
+                    updateTextField("$flagName : $flagValue")
                 }
 
                 StatusEvent.EVENT_TYPE.EVALUATION_REMOVE -> {
@@ -93,7 +93,7 @@ class MainActivity : AppCompatActivity() {
                             "SDKEvent",
                             "Flag $flagName was deleted in Harness, ensure this is cleaned up in code"
                         )
-                        logMessage("$flagName was deleted in Harness, ensure this is cleaned up in code")
+                        updateTextField("$flagName was deleted in Harness, ensure this is cleaned up in code")
                     }
                 }
 
@@ -108,9 +108,9 @@ class MainActivity : AppCompatActivity() {
         client.initialize(this, apiKey, config, target) { info, result ->
             if (result.isSuccess) {
                 val flagValue: Boolean = client.boolVariation(flagName, false)
-                logMessage("Using callback: $flagName : $flagValue")
+                updateTextField("Using callback: $flagName : $flagValue")
             } else {
-                logMessage("Callback: SDK initialization failed: ${result.error}")
+                updateTextField("Callback: SDK initialization failed: ${result.error}")
             }
         }
     }
@@ -125,7 +125,7 @@ class MainActivity : AppCompatActivity() {
         client.initialize(this, apiKey, config, target)
 
         val flagValue: Boolean = client.boolVariation(flagName, false)
-        logMessage("Using callback: $flagName : $flagValue")
+        updateTextField("Using callback: $flagName : $flagValue")
     }
 
     // Blocking option - will block UI thread! Use callback approach above if you don't require
@@ -137,14 +137,14 @@ class MainActivity : AppCompatActivity() {
 
                 if (success) {
                     val flagValue: Boolean = client.boolVariation(flagName, false)
-                    logMessage("Using callback: $flagName : $flagValue")
+                    updateTextField("Using callback: $flagName : $flagValue")
                 } else {
-                    logMessage("WaitForInit: SDK initialization timed out")
+                    updateTextField("WaitForInit: SDK initialization timed out")
                 }
 
     }
 
-    private fun logMessage(msg: String) {
+    private fun updateTextField(msg: String) {
         val tv1: TextView = findViewById(R.id.textView1)
         runOnUiThread { tv1.text = msg }
     }

--- a/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
+++ b/examples/GettingStarted/src/main/java/io/harness/cfsdk/gettingstarted/MainActivity.kt
@@ -25,6 +25,11 @@ class MainActivity : AppCompatActivity() {
     // e.g. FF_API_KEY='my key' ./gradlew installDebug
     private val apiKey: String = BuildConfig.FF_API_KEY
 
+    enum class InitMethod {
+        CALLBACK,
+        WAIT_FOR_INIT,
+        NON_BLOCKING
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,7 +56,7 @@ class MainActivity : AppCompatActivity() {
         if (streamingEnabled && pollingEnabled) {
             setupEventListener()
         }
-        
+
 
         when (method) {
             InitMethod.CALLBACK -> initializeWithCallback(sdkConfiguration, target)
@@ -124,22 +129,22 @@ class MainActivity : AppCompatActivity() {
         client.initialize(this, apiKey, config, target)
 
         val flagValue: Boolean = client.boolVariation(flagName, false)
-        updateTextField("Using callback: $flagName : $flagValue")
+        updateTextField("Using non-blocking: $flagName : $flagValue")
     }
 
     // Blocking option - will block UI thread! Use callback approach above if you don't require
     // blocking option.
     private fun initializeWithWaitForInit(config: CfConfiguration, target: Target) {
 
-            client.initialize(this, apiKey, config, target)
-            val success = client.waitForInitialization(60_000)
+        client.initialize(this, apiKey, config, target)
+        val success = client.waitForInitialization(60_000)
 
-                if (success) {
-                    val flagValue: Boolean = client.boolVariation(flagName, false)
-                    updateTextField("Using callback: $flagName : $flagValue")
-                } else {
-                    updateTextField("WaitForInit: SDK initialization timed out")
-                }
+        if (success) {
+            val flagValue: Boolean = client.boolVariation(flagName, false)
+            updateTextField("Using callback: $flagName : $flagValue")
+        } else {
+            updateTextField("WaitForInit: SDK initialization timed out")
+        }
 
     }
 
@@ -148,9 +153,5 @@ class MainActivity : AppCompatActivity() {
         runOnUiThread { tv1.text = msg }
     }
 
-    enum class InitMethod {
-        CALLBACK,
-        WAIT_FOR_INIT,
-        NON_BLOCKING
-    }
+
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.0.2')
+            version('sdk', '2.1.0')
         }
     }
 }


### PR DESCRIPTION
# What
- Implements `pollingEnabled` configuration option:
    - Thread model has been tweaked so that we break from the main sdk thread if streaming and polling are both disabled

- Fixes 
    - `AuthCallback` success result only returned once. Fail results continue to be returned as many times as required, up until the SDK initializes sucesfully for the first time.  If the sdk thread aborts after it has initialized sucesfully, and re-auth is attempted, the success and fail result will no longer be returned. 
    - If a user attempts to register an event listener at the same time an event has came in in another listener, then a `ConcurrentModificationException` could occur.  This could especially happen prior to the above `AuthCallback` fix, when a user registered their listener in the callback scope.  We now make a copy of the set and iterate over the copy. 
    - No longer re-attempts auth on `403` , instead the main sdk thread will abort permanetly and sdk code `2001` will be logged

Also updates the sample app to demonstrate each init option

# Testing
- Manual testing of all init options
-  Happy and sad paths - including bad API key and enabling/disabling internet
-  Attempt to invoke multiple call backs
-  When only polling is enabled, the SDK continues to stream
-  When streaming/polling are disabled, the SDK does not subscribe to events


