### PR TITLE
FFM-11122 Use CopyOnWriteArraySet

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.1.0";
+    public static final String ANDROID_SDK_VERSION = "2.1.1";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NetworkInfoProviding.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NetworkInfoProviding.java
@@ -2,11 +2,12 @@ package io.harness.cfsdk.cloud.network;
 
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 public abstract class NetworkInfoProviding {
 
     protected volatile boolean lastState;
-    protected final Set<NetworkListener> evaluationsObserver = ConcurrentHashMap.newKeySet();
+    protected final Set<NetworkListener> evaluationsObserver = new CopyOnWriteArraySet<>();;
 
     public abstract boolean isNetworkAvailable();
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.1.0')
+            version('sdk', '2.1.1')
         }
     }
 }


### PR DESCRIPTION
# What
We are seeing `ConcurrentModificationException` due to modifying a `ConcurrentHashSet` while iterating.  This may be similar to an issue we fixed in https://github.com/harness/ff-android-client-sdk/pull/95/files line 427. 

The fix here is to use a `CopyOnWriteArraySet` which in effect is similar to the fix we applied in the above PR.  Considering there are lots of iterations in the affected class, it seems cleaner to use this set instead of manually copying the `ConcurrentHashSet` before iterating it.

# Testing
I have not been able to reproduce the issue, but the `CopyOnWriteArraySet` allows modification of the set while it is being iterated. 