### PR TITLE
FFM-11625 Add future based `close()` method

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.2.0";
+    public static final String ANDROID_SDK_VERSION = "2.2.1";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -339,7 +339,6 @@ public class CfClient implements Closeable, Client {
             }
 
             if (sdkThread != null) {
-                sdkThread.stop();
                 sdkThread = null;
             }
 
@@ -370,7 +369,6 @@ public class CfClient implements Closeable, Client {
                 }
 
                 if (sdkThread != null) {
-                    sdkThread.stop();
                     sdkThread = null;
                 }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -5,7 +5,9 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static io.harness.cfsdk.utils.CfUtils.Text.isEmpty;
 
 import android.content.Context;
+
 import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -37,6 +39,7 @@ import io.harness.cfsdk.cloud.openapi.client.model.Variation;
 import io.harness.cfsdk.cloud.sse.EventsListener;
 import io.harness.cfsdk.common.SdkCodes;
 import io.harness.cfsdk.cloud.events.AuthCallback;
+
 public class CfClient implements Closeable, Client {
 
     private static final Logger log = LoggerFactory.getLogger(CfClient.class);
@@ -310,7 +313,7 @@ public class CfClient implements Closeable, Client {
     @Deprecated
     @Override
     public void initialize(final Context context, final String apiKey, final CfConfiguration config,
-            final Target target, final CloudCache cloudCache, @Nullable final AuthCallback authCallback) throws IllegalStateException {
+                           final Target target, final CloudCache cloudCache, @Nullable final AuthCallback authCallback) throws IllegalStateException {
         initializeInternal(context, apiKey, config, target, cloudCache, authCallback);
     }
 
@@ -323,7 +326,7 @@ public class CfClient implements Closeable, Client {
     @Deprecated
     @Override
     public void initialize(final Context context, final String apiKey, final CfConfiguration config,
-            final Target target, final CloudCache cloudCache) throws IllegalStateException {
+                           final Target target, final CloudCache cloudCache) throws IllegalStateException {
         initializeInternal(context, apiKey, config, target, cloudCache, null);
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/Client.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/Client.java
@@ -6,6 +6,9 @@ import androidx.annotation.Nullable;
 
 import org.json.JSONObject;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+
 import io.harness.cfsdk.cloud.cache.CloudCache;
 import io.harness.cfsdk.cloud.events.AuthCallback;
 import io.harness.cfsdk.cloud.events.EvaluationListener;
@@ -141,6 +144,12 @@ public interface Client extends AutoCloseable {
      * @since 1.2.0
      */
     void close();
+
+    /**
+     * Like {@link #close()} except returns a Future to indicate completion
+     * @since 2.2.1
+     */
+    Future<Boolean> closeWithFuture();
 
     /**
      * Deprecated. Use {@link io.harness.cfsdk.CfClient#initialize(Context, String, CfConfiguration, Target)} instead.

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -76,9 +76,6 @@ class SdkThread implements Runnable {
     // Used for emitting the initialize callback only once
     private boolean isAuthSuccessfulOnce = false;
 
-    private volatile boolean running = true;
-
-
     SdkThread(Context context, String apiKey, CfConfiguration config, Target target, Map<String, Set<EvaluationListener>> evaluationListenerMap, Set<EventsListener> eventsListenerSet, AuthCallback authCallback, NetworkChecker networkChecker)  {
         this.context = context;
         this.apiKey = apiKey;
@@ -566,7 +563,7 @@ class SdkThread implements Runnable {
             } catch (InterruptedException e) {
                 log.trace("sdk restart delay interrupted", e);
             }
-        } while (running && !Thread.currentThread().isInterrupted());
+        } while (!Thread.currentThread().isInterrupted());
     }
 
 
@@ -586,11 +583,6 @@ class SdkThread implements Runnable {
                 log.trace("sdk network wait interrupted", e);
             }
         } while (counter-- > 0);
-    }
-
-    void stop() {
-        running = false;
-        Thread.currentThread().interrupt();
     }
 
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -76,6 +76,9 @@ class SdkThread implements Runnable {
     // Used for emitting the initialize callback only once
     private boolean isAuthSuccessfulOnce = false;
 
+    private volatile boolean running = true;
+
+
     SdkThread(Context context, String apiKey, CfConfiguration config, Target target, Map<String, Set<EvaluationListener>> evaluationListenerMap, Set<EventsListener> eventsListenerSet, AuthCallback authCallback, NetworkChecker networkChecker)  {
         this.context = context;
         this.apiKey = apiKey;
@@ -563,8 +566,10 @@ class SdkThread implements Runnable {
             } catch (InterruptedException e) {
                 log.trace("sdk restart delay interrupted", e);
             }
-        } while (true);
+        } while (running && !Thread.currentThread().isInterrupted());
     }
+
+
 
     private void waitForNetworkToGoOnline() {
         log.info("Network is offline, SDK going to sleep");
@@ -581,6 +586,11 @@ class SdkThread implements Runnable {
                 log.trace("sdk network wait interrupted", e);
             }
         } while (counter-- > 0);
+    }
+
+    void stop() {
+        running = false;
+        Thread.currentThread().interrupt();
     }
 
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsManager.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsManager.java
@@ -151,20 +151,8 @@ public class AnalyticsManager implements Closeable {
 
     public void close() {
         log.debug("Closing Metrics thread");
-
         flushMetrics();
-        scheduledExecutorService.shutdown();
-        try {
-            if (!scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
-                scheduledExecutorService.shutdownNow();
-                if (!scheduledExecutorService.awaitTermination(5, TimeUnit.SECONDS)) {
-                    log.error("Metrics thread pool did not terminate");
-                }
-            }
-        } catch (InterruptedException ex) {
-            log.warn("Timed out waiting for metrics to flush on close", ex);
-            Thread.currentThread().interrupt();
-        }
+        scheduledExecutorService.shutdownNow();
         SdkCodes.infoMetricsThreadExited();
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/common/SdkCodes.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/common/SdkCodes.java
@@ -41,6 +41,16 @@ public class SdkCodes {
       log.info(sdkErrMsg(2000, sdkVersion));
   }
 
+  public static void infoSdkClosing() {
+    if (log.isInfoEnabled())
+      log.info(sdkErrMsg(3000));
+  }
+
+  public static void infoSdkClosed() {
+    if (log.isInfoEnabled())
+      log.info(sdkErrMsg(3001));
+  }
+
   public static void infoPollingStopped() {
     if (log.isInfoEnabled())
       log.info(sdkErrMsg(4001));
@@ -110,6 +120,9 @@ public class SdkCodes {
     put(4000, "Polling started, intervalMs:");
     put(4001, "Polling stopped");
 
+    put(3000, "Closing SDK");
+    put(3001, "SDK Closed successfully");
+
     put(5000, "SSE stream connected ok");
     put(5001, "SSE stream disconnected, reason:");
     put(5002, "SSE event received:");
@@ -141,6 +154,7 @@ public class SdkCodes {
   private static String getErrClass(int errorCode) {
     if (errorCode >= 1000 && errorCode <= 1999) return "init";
     else if (errorCode >= 2000 && errorCode <= 2999) return "auth";
+    else if (errorCode >= 3000 && errorCode <= 3999) return "close";
     else if (errorCode >= 4000 && errorCode <= 4999) return "poll";
     else if (errorCode >= 5000 && errorCode <= 5999) return "stream";
     else if (errorCode >= 6000 && errorCode <= 6999) return "eval";

--- a/cfsdk/src/test/java/io/harness/cfsdk/common/SdkCodesTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/common/SdkCodesTest.java
@@ -18,6 +18,8 @@ public class SdkCodesTest {
             infoSdkInitOk();
             infoSdkWaitingForInit();
             infoSdkAuthOk("1.2.3");
+            infoSdkClosing();
+            infoSdkClosed();
             infoPollingStopped();
             infoStreamConnected();
             infoStreamEventReceived(null);

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.2.0')
+            version('sdk', '2.2.1')
         }
     }
 }


### PR DESCRIPTION
# What
To resolve a Flutter SDK issue https://github.com/harness/ff-flutter-client-sdk/issues/37 

- adds an async method to close the SDK, which returns a `Future` on completion. 
- synchronizes the `initialize` and `close` methods with a lock 

Also adds the SDK Codes `3xxx` for closing the SDK

# Testing
Manual - getting started sample app and Flutter SDK sample app