### PR TITLE
FFM-11750 Remove unused internal cache implementation

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -69,7 +69,6 @@ dependencies {
     implementation 'io.swagger:swagger-annotations:1.5.24'
     implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.threeten:threetenbp:1.6.9'
-    implementation 'com.orhanobut:hawk:2.0.1'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.10.0'

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.2.1";
+    public static final String ANDROID_SDK_VERSION = "2.2.2";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -1,7 +1,6 @@
 package io.harness.cfsdk;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-
 import static io.harness.cfsdk.utils.CfUtils.Text.isEmpty;
 
 import android.content.Context;
@@ -14,22 +13,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
-import java.util.concurrent.TimeUnit;
 
-import io.harness.cfsdk.cloud.cache.CloudCache;
 import io.harness.cfsdk.cloud.analytics.AnalyticsManager;
 import io.harness.cfsdk.cloud.analytics.AnalyticsPublisherService;
+import io.harness.cfsdk.cloud.cache.CloudCache;
+import io.harness.cfsdk.cloud.events.AuthCallback;
 import io.harness.cfsdk.cloud.events.EvaluationListener;
 import io.harness.cfsdk.cloud.model.Target;
 import io.harness.cfsdk.cloud.network.NetworkChecker;
@@ -38,7 +35,6 @@ import io.harness.cfsdk.cloud.openapi.client.model.Evaluation;
 import io.harness.cfsdk.cloud.openapi.client.model.Variation;
 import io.harness.cfsdk.cloud.sse.EventsListener;
 import io.harness.cfsdk.common.SdkCodes;
-import io.harness.cfsdk.cloud.events.AuthCallback;
 
 public class CfClient implements Closeable, Client {
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -81,7 +81,7 @@ class SdkThread implements Runnable {
         this.apiKey = apiKey;
         this.config = config;
         this.target = target;
-        this.cache = (config.getCache() != null) ? config.getCache() : new DefaultCache(context, target.getIdentifier(), apiKey);
+        this.cache = (config.getCache() != null) ? config.getCache() : new DefaultCache();
         this.callbackExecutor.execute(() -> Thread.currentThread().setName("CallbackThread"));
         this.evaluationListenerMap = evaluationListenerMap;
         this.eventsListenerSet = eventsListenerSet;

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -137,6 +137,9 @@ class SdkThread implements Runnable {
 
         if (networkUnavailable()) {
             log.info("Will not auth, network offline");
+            if (authCallback != null && !isAuthSuccessfulOnce) {
+                authCallback.authorizationSuccess(null, new AuthResult(false, new NetworkOffline()));
+            }
             throw new NetworkOffline();
         }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
@@ -1,24 +1,18 @@
 package io.harness.cfsdk.cloud.cache;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.util.stream.Collectors.toList;
 
 import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
 
-import android.content.Context;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import com.orhanobut.hawk.Hawk;
 
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -29,41 +23,10 @@ public class DefaultCache implements CloudCache {
 
     public static final String METADATA_KEY_LAST_UPDATED = "LAST_UPDATED";
     private final Map<String, Evaluation> evaluations;
-    private final InternalCache internalCache;
-    private final String cacheId;
 
-    public interface InternalCache {
-        default void init(final Context appContext) { Hawk.init(appContext).build(); }
-        default void saveAll(String cacheId, Map<String, Evaluation> evaluations) { Hawk.put(cacheId, evaluations); }
-        default Map<String, Evaluation> loadAll(String cacheId, Map<String, Evaluation> defaultMap) { return Hawk.get(cacheId, defaultMap); }
-        default void deleteAll() { Hawk.deleteAll(); }
-        default void updateMetadata(String cacheId, Map<String, String> metadata) { Hawk.put(cacheId + "_METADATA", metadata); }
-    }
 
-    public DefaultCache(final Context appContext, String targetId, String apiKey) {
-        this(appContext, new InternalCache() {}, targetId, apiKey);
-    }
-
-    public DefaultCache(final Context appContext, final InternalCache cache, String targetId, String apiKey) {
-        internalCache = cache;
-        internalCache.init(appContext);
-        evaluations = load();
-        cacheId = getCacheId(targetId, apiKey);
-    }
-
-    private String getCacheId(String targetId, String apiKey) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            digest.update(targetId.getBytes(UTF_8));
-            digest.update(apiKey.getBytes(UTF_8));
-            return "HARNESS_FF_CACHE_" + String.format("%032X", new BigInteger(1, digest.digest())) + getVersionSuffix();
-        } catch (NoSuchAlgorithmException ex) {
-            return "HARNESS_FF_CACHE_" + targetId + getVersionSuffix();
-        }
-    }
-
-    private String getVersionSuffix() {
-        return "_v" + ANDROID_SDK_VERSION.replace("-SNAPSHOT", "").replace(".", "");
+    public DefaultCache() {
+        evaluations = new ConcurrentHashMap<>();
     }
 
     @Override
@@ -75,8 +38,6 @@ public class DefaultCache implements CloudCache {
     @Override
     public void saveEvaluation(final String env, final String key, final Evaluation evaluation) {
         evaluations.put(makeKey(env, key), evaluation);
-        internalCache.saveAll(cacheId, evaluations);
-        updateMetadata(env);
     }
 
     @Override
@@ -91,41 +52,23 @@ public class DefaultCache implements CloudCache {
         for (final Evaluation eval : newEvaluations) {
             evaluations.put(makeKey(env, eval.getFlag()), eval);
         }
-        internalCache.saveAll(cacheId, evaluations);
-        updateMetadata(env);
     }
 
     @Override
     public void removeEvaluation(final String env, final String key) {
         evaluations.remove(makeKey(env, key));
-        internalCache.saveAll(cacheId, evaluations);
-        updateMetadata(env);
     }
 
     @Override
     public void clear(String env) {
         evaluations.clear();
-        internalCache.saveAll(cacheId, evaluations);
-        updateMetadata(env);
     }
 
-    private void updateMetadata(String env) {
-        final Map<String, String> metadata = Collections.singletonMap(METADATA_KEY_LAST_UPDATED + '.' + env, Instant.now().toString());
-        internalCache.updateMetadata(cacheId, metadata);
-    }
+
 
     private String makeKey(String env, String key) {
         return env + '_' + key;
     }
 
-    private ConcurrentHashMap<String, Evaluation> load() {
-        final ConcurrentHashMap<String, Evaluation> defaultMap = new ConcurrentHashMap<>();
-        try {
-            return new ConcurrentHashMap<>(internalCache.loadAll(cacheId, defaultMap));
-        } catch (Exception ex) {
-            // Possible cache corruption, reset the cache on disk and let it rebuild
-            internalCache.deleteAll();
-            return new ConcurrentHashMap<>(internalCache.loadAll(cacheId, defaultMap));
-        }
-    }
+
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/cache/DefaultCache.java
@@ -1,17 +1,8 @@
 package io.harness.cfsdk.cloud.cache;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
-import static io.harness.cfsdk.AndroidSdkVersion.ANDROID_SDK_VERSION;
-
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-
-import java.math.BigInteger;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +12,6 @@ import io.harness.cfsdk.cloud.openapi.client.model.Evaluation;
 
 public class DefaultCache implements CloudCache {
 
-    public static final String METADATA_KEY_LAST_UPDATED = "LAST_UPDATED";
     private final Map<String, Evaluation> evaluations;
 
 
@@ -63,7 +53,6 @@ public class DefaultCache implements CloudCache {
     public void clear(String env) {
         evaluations.clear();
     }
-
 
 
     private String makeKey(String env, String key) {

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -333,6 +333,42 @@ public class CfClientTest {
         assertEquals(60, cache.getCacheHitCountForEvaluation("testFlag"));
     }
 
+    @Test
+    public void shouldUseDefaultCacheWhenCustomCacheNotProvided() throws Exception {
+        final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
+        dispatcher.moreEvaluations.add(new Evaluation().flag("testFlag").kind("boolean").value("false").identifier("testFlag"));
+
+        try (MockWebServer mockSvr = new MockWebServer()) {
+            mockSvr.setDispatcher(dispatcher);
+            mockSvr.start();
+
+            try (final CfClient client = new CfClient()) {
+                client.setNetworkChecker(ctx -> true);
+
+                final CfConfiguration config = CfConfiguration.builder()
+                        .baseUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                        .eventUrl(makeServerUrl(mockSvr.getHostName(), mockSvr.getPort()))
+                        .enableAnalytics(false)
+                        .enableStream(true)
+                        .debug(true)
+                        .build();
+
+                client.initialize(
+                        makeMockContextWithNetworkOnline(),
+                        "dummykey",
+                        config,
+                        DUMMY_TARGET
+                );
+
+                assertTrue(client.waitForInitialization(30_000));
+
+                // Assert the evaluations are correct
+                boolean evalResult = client.boolVariation("testFlag", false);
+                assertTrue(evalResult);
+            }
+        }
+    }
+
     private CloudCache makeMockCache() {
         final CloudCache cache = new MockedCache();
         cache.saveEvaluation("Production", "anyone@anywhere.com", new Evaluation().value("dummy"));

--- a/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/CfClientTest.java
@@ -336,7 +336,7 @@ public class CfClientTest {
     @Test
     public void shouldUseDefaultCacheWhenCustomCacheNotProvided() throws Exception {
         final MockWebServerDispatcher dispatcher = new MockWebServerDispatcher();
-        dispatcher.moreEvaluations.add(new Evaluation().flag("testFlag").kind("boolean").value("false").identifier("testFlag"));
+        dispatcher.moreEvaluations.add(new Evaluation().flag("testFlag").kind("boolean").value("true").identifier("testFlag"));
 
         try (MockWebServer mockSvr = new MockWebServer()) {
             mockSvr.setDispatcher(dispatcher);

--- a/cfsdk/src/test/java/io/harness/cfsdk/cloud/DefaultCacheTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/cloud/DefaultCacheTest.java
@@ -8,56 +8,23 @@ import static org.mockito.Mockito.mock;
 import static io.harness.cfsdk.cloud.cache.DefaultCache.METADATA_KEY_LAST_UPDATED;
 
 import android.content.Context;
+
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
 import io.harness.cfsdk.cloud.cache.DefaultCache;
 import io.harness.cfsdk.cloud.openapi.client.model.Evaluation;
 
 public class DefaultCacheTest {
 
-    static class TestBackendCache implements DefaultCache.InternalCache {
-
-        private final Map<String, Map<String, Evaluation>> map = new HashMap<>();
-        Map<String, String> metadata;
-
-        @Override
-        public void saveAll(String key, Map<String, Evaluation> evaluations) {
-            map.put(key, new HashMap<>(evaluations));
-        }
-
-        @Override
-        public Map<String, Evaluation> loadAll(String key, Map<String, Evaluation> defaultMap) {
-            Map<String, Evaluation> m = map.get(key);
-            return (m == null) ? new HashMap<>() : new HashMap<>(m);
-        }
-
-        @Override
-        public void deleteAll() {
-            map.clear();
-        }
-
-        @Override
-        public void init(Context appContext) {
-        }
-
-        @Override
-        public void updateMetadata(String cacheId, Map<String, String> metadata) {
-            this.metadata = metadata;
-        }
-    }
-
-    private TestBackendCache backingCache = new TestBackendCache();
 
     @Test
     public void testCache() {
-
-        Context mockContext = mock(Context.class);
-        DefaultCache cache = new DefaultCache(mockContext, backingCache, "dummyTargetId", "dummyApyKey");
-
+        DefaultCache cache = new DefaultCache();
         String env = "dummyenv";
 
         Evaluation eval1 = new Evaluation().flag("flag1");
@@ -100,11 +67,6 @@ public class DefaultCacheTest {
         assertNull(cache.getEvaluation(env, "dummykey4"));
         assertNull(cache.getEvaluation(env, "dummykey5"));
         assertNull(cache.getEvaluation(env, "dummykey6"));
-
-        assertNotNull(backingCache.metadata);
-        assertEquals(1, backingCache.metadata.size());
-        assertTrue(backingCache.metadata.containsKey(METADATA_KEY_LAST_UPDATED + '.' + env));
-
     }
 
 }

--- a/cfsdk/src/test/java/io/harness/cfsdk/cloud/DefaultCacheTest.java
+++ b/cfsdk/src/test/java/io/harness/cfsdk/cloud/DefaultCacheTest.java
@@ -3,18 +3,11 @@ package io.harness.cfsdk.cloud;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static io.harness.cfsdk.cloud.cache.DefaultCache.METADATA_KEY_LAST_UPDATED;
-
-import android.content.Context;
 
 import org.junit.Test;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import io.harness.cfsdk.cloud.cache.DefaultCache;
 import io.harness.cfsdk.cloud.openapi.client.model.Evaluation;

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -39,6 +39,7 @@ client.initialize(this, apiKey, sdkConfiguration, target)
 ### Synchronous (Blocking) Initialization
 For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method.
 This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward.
+If the SDK disconnects from Harness SaaS after successfully initializing, it will be able to use cached values for evaluations and will attempt to reconnect.
 
 This will block the UI thread, so use synchronous initialization only if absolutely required. It is recommended to provide a timeout to this call, so in the event
 the SDK is unable to initialize in a set time, then default variations can be used.  

--- a/docs/further_reading.md
+++ b/docs/further_reading.md
@@ -24,7 +24,7 @@ client.initialize(this, apiKey, sdkConfiguration, target)
 }
 ```
 This approach is non-blocking and leverages a callback mechanism to inform the application about the SDK's initialization status. Here's how it works:
-* Success Callback: This callback is invoked once when the SDK is successfully initialized. It signifies that the SDK is ready for use. 
+* Success Callback: This callback is invoked once when the SDK is successfully initialized. It signifies that the SDK is ready for use.  If the SDK disconnects from Harness SaaS after this point, it will be able to use cached values for evaluations and will attempt to reconnect.
 
 * Failure Callback: This callback may be invoked multiple times if the SDK encounters errors during the initialization process. Each invocation provides an error detailing the cause of failure. The SDK will automatically attempt to retry authentication, leading to multiple invocations of this callback until a successful initialization occurs.
 
@@ -40,7 +40,9 @@ client.initialize(this, apiKey, sdkConfiguration, target)
 For scenarios where it's critical to have feature flags loaded and evaluated before proceeding, the SDK offers a blocking initialization method.
 This approach ensures that the SDK is fully authenticated and the feature flags are populated from the cache or network before moving forward.
 
-This will block the UI thread, so use synchros initialization only if absolutely required.
+This will block the UI thread, so use synchronous initialization only if absolutely required. It is recommended to provide a timeout to this call, so in the event
+the SDK is unable to initialize in a set time, then default variations can be used.  
+The SDK will retry to initialize in the background after a timeout has occurred, but default variations will be served until it can initialize. 
 
 Usage:
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.2.1')
+            version('sdk', '2.2.2')
         }
     }
 }


### PR DESCRIPTION
# What
- V2 of this SDK did not remove an unused `InternalCache` implementation which is backed by the `Hawk` library.  This cache was not utilised in V1, and should not have made it into V2.  Additionaly, this cache was adding significant latency to init times, because of the new thread model in V2. 

- Fixes a bug where if the callback is used to initialise and the device is currently offline, then no callback will be emitted until the device comes online and gets an init result.

# Testing
- Manual: 
    -  all evaluations still cached in memory:
        - on init
        - when streamed
        - when polled 
    -  init latency times are back to expected levels
- New unit test for client init flow