### PR TITLE
FFM-11779 Fix SDK Client Not Closing Correctly

### DIFF
--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.2.2";
+    public static final String ANDROID_SDK_VERSION = "2.2.3";
 }

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -27,6 +27,7 @@ import io.harness.cfsdk.cloud.analytics.AnalyticsManager;
 import io.harness.cfsdk.cloud.analytics.AnalyticsPublisherService;
 import io.harness.cfsdk.cloud.cache.CloudCache;
 import io.harness.cfsdk.cloud.events.AuthCallback;
+import io.harness.cfsdk.cloud.events.AuthResult;
 import io.harness.cfsdk.cloud.events.EvaluationListener;
 import io.harness.cfsdk.cloud.model.Target;
 import io.harness.cfsdk.cloud.network.NetworkChecker;
@@ -121,6 +122,9 @@ public class CfClient implements Closeable, Client {
 
         } catch (Exception e) {
             log.warn(e.getMessage(), e);
+            if (authCallback != null) {
+                authCallback.authorizationSuccess(null, new AuthResult(false, e));
+            }
         }
     }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/CfClient.java
@@ -339,6 +339,7 @@ public class CfClient implements Closeable, Client {
             }
 
             if (sdkThread != null) {
+                sdkThread.stopRunning();
                 sdkThread = null;
             }
 
@@ -369,6 +370,7 @@ public class CfClient implements Closeable, Client {
                 }
 
                 if (sdkThread != null) {
+                    sdkThread.stopRunning();
                     sdkThread = null;
                 }
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -166,7 +166,7 @@ class SdkThread implements Runnable {
             bearerToken = api.authenticate(authRequest).getAuthToken();
         } catch (ApiException ex) {
             if (ex.getCause() instanceof InterruptedIOException) {
-                log.debug("Streaming interrupted, not retrying");
+                log.debug("Authentication interrupted, not retrying");
                 throw new InterruptedException();
             }
             if (authCallback != null && ex.getCode() != 200 && !isAuthSuccessfulOnce) {

--- a/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/SdkThread.java
@@ -67,7 +67,7 @@ class SdkThread implements Runnable {
     private final Set<EventsListener> eventsListenerSet;
     private final AuthCallback authCallback;
     private final NetworkChecker networkChecker;
-    private final AtomicBoolean running; // Add AtomicBoolean running flag
+    private final AtomicBoolean running;
 
 
 

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsManager.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/analytics/AnalyticsManager.java
@@ -92,13 +92,18 @@ public class AnalyticsManager implements Closeable {
         this.networkChecker = networkChecker;
 
         final long frequencyMs = config.getMetricsPublishingIntervalInMillis();
-        scheduledExecutorService.scheduleAtFixedRate(this::postMetricsThread,frequencyMs/2, frequencyMs, TimeUnit.MILLISECONDS);
+        scheduledExecutorService.scheduleWithFixedDelay(this::postMetricsThread,frequencyMs/2, frequencyMs, TimeUnit.MILLISECONDS);
         SdkCodes.infoMetricsThreadStarted((int)frequencyMs/1000);
     }
 
     public void postMetricsThread() {
         log.debug("Running metrics thread iteration. frequencyMapSize={}", frequencyMap.size());
         Thread.currentThread().setName("Metrics Thread");
+
+        if (Thread.currentThread().isInterrupted()) {
+            log.info("Metrics thread was interrupted, stopping execution");
+            return;
+        }
 
         if (!networkChecker.isNetworkAvailable(context)) {
             log.info("Network is offline, skipping metrics post");

--- a/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/cloud/network/NewRetryInterceptor.java
@@ -5,6 +5,7 @@ import android.text.format.DateUtils;
 import java.io.IOException;
 
 
+import java.io.InterruptedIOException;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -61,6 +62,8 @@ public class NewRetryInterceptor implements Interceptor {
               "Connection to {} was successful after {} attempts", chain.request().url(), tryCount);
         }
 
+      } catch (InterruptedIOException ex) {
+        throw ex;
       } catch (Exception ex) {
         log.trace("Error while attempting to make request", ex);
         msg = ex.getClass().getSimpleName() + ": " + ex.getMessage();

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.2.2')
+            version('sdk', '2.2.3')
         }
     }
 }


### PR DESCRIPTION
# What
When `client.Close()` or `client.CloseWithFuture()` was called, the `Main SDK Thread` did not handle `InterruptedException` correctly because they were getting swallowed by the main capturing of `Runnable` exceptions. In that case, the `Runnable` being caught would mean the SDK would sleep for a minute and retry. 
This fix ensures that the: 
- The `Run` method catches InterruptedExceptions and breaks the `Main SDK Thread`.
- The http `Interceptor` which is used for http requests throws InterruptedException for any in-flight requests, mainly streaming which is long-lived, but also for authentication and polling. Before these would have retried.  These come through as `APIException` but the `cause` is obtained and checked. 

Also fixes unrelated bug where if the API key was null or empty, the callback would not be invoked.

# Why
Previously, if the SDK was closed it would re-authenticate and restart restart streaming one minute later.  This would lead to a memory leak if clients were being started and stopped regularly. 

# Testing
Manual:
Main SDK Thread:
- Calling `close()` immediately after initialising interrupts the authentication request and the main SDK thread exists
- Calling `close()` 5 seconds after initialising interrupts the streaming request and the main SDK thread exists
- Calling `close()` with streaming disabled interrupts the polling request and the main SDK thread exits
- Calling `close()` with streaming and polling disabled does not affect the main SDK thread, as it will already exit in this configuration.

Metrics Thread:
- Metrics Thread scheduler is terminated after `close()` is called as normal - this behaviour was already working.