### PR TITLE
FFM-12237 Remove unused dependency

### DIFF
--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -68,7 +68,6 @@ dependencies {
     implementation "com.squareup.okhttp3:logging-interceptor:$okhttp3_version"
     implementation 'io.swagger:swagger-annotations:1.5.24'
     implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'org.threeten:threetenbp:1.6.9'
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:4.10.0'

--- a/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
+++ b/cfsdk/src/main/java/io/harness/cfsdk/AndroidSdkVersion.java
@@ -1,5 +1,5 @@
 package io.harness.cfsdk;
 
 public class AndroidSdkVersion {
-    public static final String ANDROID_SDK_VERSION = "2.2.3";
+    public static final String ANDROID_SDK_VERSION = "2.2.4";
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // main sdk version
-            version('sdk', '2.2.3')
+            version('sdk', '2.2.4')
         }
     }
 }


### PR DESCRIPTION
# What
Removes unused dependency `org.threeten:threetenbp:1.6.9`.  

# Why
Customer flagged a dependency conflict with threeten, which lead me to find this was no longer being used at all in the SDK. 

# Testing
Manual 