### PR TITLE
techdebt: [FFM-12658]: Bump Android Gradle Plugin to 8.13.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools:r8:8.2.42'
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools:r8:8.13.6'
+        classpath 'com.android.tools.build:gradle:8.13.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'org.owasp:dependency-check-gradle:9.0.9'
     }

--- a/cfsdk/build.gradle
+++ b/cfsdk/build.gradle
@@ -29,8 +29,6 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 33
-        versionCode getVersionCode(libs.versions.sdk.get())
-        versionName libs.versions.sdk.get()
         consumerProguardFiles "consumer-rules.pro"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }


### PR DESCRIPTION
- Bump AGP to get latest bug fixes and support latest Android Studio